### PR TITLE
feat: integra CRUD completo de benefícios ao backend

### DIFF
--- a/app/app/Http/Controllers/BenefitController.php
+++ b/app/app/Http/Controllers/BenefitController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\StoreBenefitRequest;
+use App\Http\Requests\UpdateBenefitRequest;
+use App\Models\Benefit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+
+class BenefitController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Benefit::with('creator');
+
+        if ($request->filled('search')) {
+            $search = $request->input('search');
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'ilike', "%{$search}%")
+                  ->orWhere('code', 'ilike', "%{$search}%")
+                  ->orWhere('category', 'ilike', "%{$search}%");
+            });
+        }
+
+        if ($request->filled('category') && $request->input('category') !== 'all') {
+            $query->where('category', $request->input('category'));
+        }
+
+        $benefits = $query->orderBy('id', 'desc')->paginate(8)->withQueryString();
+
+        return Inertia::render('beneficios', [
+            'benefits' => $benefits,
+        ]);
+    }
+
+    public function store(StoreBenefitRequest $request)
+    {
+        $data = $request->validated();
+
+        $imagePath = null;
+        if ($request->hasFile('image')) {
+            $imagePath = $request->file('image')->store('benefits', 'public');
+        }
+
+        Benefit::create([
+            'code' => Benefit::generateCode(),
+            'name' => $data['name'],
+            'category' => $data['category'],
+            'stock' => $data['quantity'],
+            'status' => 'Ativo',
+            'donor' => $data['donor'] ?? null,
+            'validity' => $data['validity'] ?? null,
+            'notes' => $data['notes'] ?? null,
+            'image_path' => $imagePath,
+            'created_by' => auth()->id(),
+        ]);
+
+        return redirect()->route('beneficios');
+    }
+
+    public function update(UpdateBenefitRequest $request, Benefit $benefit)
+    {
+        $data = $request->validated();
+
+        $imagePath = $benefit->image_path;
+        if ($request->hasFile('image')) {
+            if ($imagePath) {
+                Storage::disk('public')->delete($imagePath);
+            }
+            $imagePath = $request->file('image')->store('benefits', 'public');
+        }
+
+        $updateData = [
+            'name' => $data['name'] ?? $benefit->name,
+            'category' => $data['category'] ?? $benefit->category,
+            'stock' => $data['stock'] ?? $benefit->stock,
+            'status' => $data['status'] ?? $benefit->status,
+            'donor' => $data['donor'] ?? $benefit->donor,
+            'validity' => $data['validity'] ?? $benefit->validity,
+            'notes' => $data['notes'] ?? $benefit->notes,
+        ];
+
+        if ($request->hasFile('image') || $request->has('remove_image')) {
+            $updateData['image_path'] = $imagePath;
+        }
+
+        $benefit->update($updateData);
+
+        return redirect()->route('beneficios');
+    }
+
+    public function destroy(Benefit $benefit)
+    {
+        if ($benefit->image_path) {
+            Storage::disk('public')->delete($benefit->image_path);
+        }
+
+        $benefit->delete();
+
+        return redirect()->route('beneficios');
+    }
+}

--- a/app/app/Http/Controllers/BenefitController.php
+++ b/app/app/Http/Controllers/BenefitController.php
@@ -44,8 +44,7 @@ class BenefitController extends Controller
             $imagePath = $request->file('image')->store('benefits', 'public');
         }
 
-        Benefit::create([
-            'code' => Benefit::generateCode(),
+        $benefit = Benefit::create([
             'name' => $data['name'],
             'category' => $data['category'],
             'stock' => $data['quantity'],
@@ -57,6 +56,8 @@ class BenefitController extends Controller
             'created_by' => auth()->id(),
         ]);
 
+        $benefit->update(['code' => $benefit->generateCode()]);
+
         return redirect()->route('beneficios');
     }
 
@@ -65,6 +66,14 @@ class BenefitController extends Controller
         $data = $request->validated();
 
         $imagePath = $benefit->image_path;
+
+        if ($request->has('remove_image')) {
+            if ($imagePath) {
+                Storage::disk('public')->delete($imagePath);
+            }
+            $imagePath = null;
+        }
+
         if ($request->hasFile('image')) {
             if ($imagePath) {
                 Storage::disk('public')->delete($imagePath);

--- a/app/app/Http/Requests/StoreBenefitRequest.php
+++ b/app/app/Http/Requests/StoreBenefitRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreBenefitRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'category' => ['required', 'in:Alimentação,Financeiro,Saúde,Vestuário,Educação'],
+            'quantity' => ['required', 'integer', 'min:1'],
+            'donor' => ['nullable', 'string', 'max:255'],
+            'validity' => ['nullable', 'date'],
+            'notes' => ['nullable', 'string'],
+            'image' => ['nullable', 'file', 'mimes:png,jpg,jpeg,pdf', 'max:5120'],
+        ];
+    }
+}

--- a/app/app/Http/Requests/UpdateBenefitRequest.php
+++ b/app/app/Http/Requests/UpdateBenefitRequest.php
@@ -18,9 +18,9 @@ class UpdateBenefitRequest extends FormRequest
             'category' => ['sometimes', 'required', 'in:Alimentação,Financeiro,Saúde,Vestuário,Educação'],
             'stock' => ['sometimes', 'required', 'integer', 'min:0'],
             'status' => ['sometimes', 'required', 'in:Ativo,Revisão,Inativo'],
-            'donor' => ['nullable', 'string', 'max:255'],
-            'validity' => ['nullable', 'date'],
-            'notes' => ['nullable', 'string'],
+            'donor' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'validity' => ['sometimes', 'nullable', 'date'],
+            'notes' => ['sometimes', 'nullable', 'string'],
             'image' => ['nullable', 'file', 'mimes:png,jpg,jpeg,pdf', 'max:5120'],
         ];
     }

--- a/app/app/Http/Requests/UpdateBenefitRequest.php
+++ b/app/app/Http/Requests/UpdateBenefitRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateBenefitRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'category' => ['sometimes', 'required', 'in:Alimentação,Financeiro,Saúde,Vestuário,Educação'],
+            'stock' => ['sometimes', 'required', 'integer', 'min:0'],
+            'status' => ['sometimes', 'required', 'in:Ativo,Revisão,Inativo'],
+            'donor' => ['nullable', 'string', 'max:255'],
+            'validity' => ['nullable', 'date'],
+            'notes' => ['nullable', 'string'],
+            'image' => ['nullable', 'file', 'mimes:png,jpg,jpeg,pdf', 'max:5120'],
+        ];
+    }
+}

--- a/app/app/Models/Benefit.php
+++ b/app/app/Models/Benefit.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Benefit extends Model
+{
+    use HasFactory;
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'stock' => 'integer',
+        'validity' => 'date',
+    ];
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public static function generateCode(): string
+    {
+        $latest = static::orderBy('id', 'desc')->first();
+        $nextId = $latest ? $latest->id + 1 : 1;
+        return 'BNF-' . str_pad((string) $nextId, 3, '0', STR_PAD_LEFT);
+    }
+}

--- a/app/app/Models/Benefit.php
+++ b/app/app/Models/Benefit.php
@@ -21,10 +21,8 @@ class Benefit extends Model
         return $this->belongsTo(User::class, 'created_by');
     }
 
-    public static function generateCode(): string
+    public function generateCode(): string
     {
-        $latest = static::orderBy('id', 'desc')->first();
-        $nextId = $latest ? $latest->id + 1 : 1;
-        return 'BNF-' . str_pad((string) $nextId, 3, '0', STR_PAD_LEFT);
+        return 'BNF-' . str_pad((string) $this->id, 3, '0', STR_PAD_LEFT);
     }
 }

--- a/app/database/migrations/2026_06_11_000000_create_benefits_table.php
+++ b/app/database/migrations/2026_06_11_000000_create_benefits_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('benefits', function (Blueprint $table) {
+            $table->id();
+            $table->string('code')->unique();
+            $table->string('name');
+            $table->enum('category', ['Alimentação', 'Financeiro', 'Saúde', 'Vestuário', 'Educação']);
+            $table->integer('stock')->default(0);
+            $table->enum('status', ['Ativo', 'Revisão', 'Inativo'])->default('Ativo');
+            $table->string('donor')->nullable();
+            $table->date('validity')->nullable();
+            $table->text('notes')->nullable();
+            $table->string('image_path')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('benefits');
+    }
+};

--- a/app/database/migrations/2026_06_11_000001_make_benefits_code_nullable.php
+++ b/app/database/migrations/2026_06_11_000001_make_benefits_code_nullable.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('benefits', function (Blueprint $table) {
+            $table->string('code')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('benefits', function (Blueprint $table) {
+            $table->string('code')->nullable(false)->change();
+        });
+    }
+};

--- a/app/database/seeders/BenefitSeeder.php
+++ b/app/database/seeders/BenefitSeeder.php
@@ -30,9 +30,9 @@ class BenefitSeeder extends Seeder
             ['name' => 'Voucher R$ 50', 'category' => 'Financeiro', 'stock' => 110, 'status' => 'Ativo'],
         ];
 
-        foreach ($benefits as $index => $data) {
-            $code = 'BNF-' . str_pad((string) ($index + 1), 3, '0', STR_PAD_LEFT);
-            Benefit::create(array_merge($data, ['code' => $code]));
+        foreach ($benefits as $data) {
+            $benefit = Benefit::create($data);
+            $benefit->update(['code' => $benefit->generateCode()]);
         }
     }
 }

--- a/app/database/seeders/BenefitSeeder.php
+++ b/app/database/seeders/BenefitSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Benefit;
+use Illuminate\Database\Seeder;
+
+class BenefitSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $benefits = [
+            ['name' => 'Cesta básica padrão', 'category' => 'Alimentação', 'stock' => 145, 'status' => 'Ativo'],
+            ['name' => 'Voucher R$ 100', 'category' => 'Financeiro', 'stock' => 50, 'status' => 'Ativo'],
+            ['name' => 'Kit higiene', 'category' => 'Saúde', 'stock' => 210, 'status' => 'Ativo'],
+            ['name' => 'Cesta básica completa', 'category' => 'Alimentação', 'stock' => 85, 'status' => 'Ativo'],
+            ['name' => 'Auxílio gás', 'category' => 'Financeiro', 'stock' => 12, 'status' => 'Ativo'],
+            ['name' => 'Kit material escolar', 'category' => 'Educação', 'stock' => 67, 'status' => 'Ativo'],
+            ['name' => 'Cesta natalina', 'category' => 'Alimentação', 'stock' => 8, 'status' => 'Revisão'],
+            ['name' => 'Voucher R$ 200', 'category' => 'Financeiro', 'stock' => 30, 'status' => 'Ativo'],
+            ['name' => 'Kit primeiros socorros', 'category' => 'Saúde', 'stock' => 15, 'status' => 'Revisão'],
+            ['name' => 'Uniforme escolar', 'category' => 'Vestuário', 'stock' => 42, 'status' => 'Ativo'],
+            ['name' => 'Cesta básica leve', 'category' => 'Alimentação', 'stock' => 180, 'status' => 'Ativo'],
+            ['name' => 'Auxílio transporte', 'category' => 'Financeiro', 'stock' => 5, 'status' => 'Revisão'],
+            ['name' => 'Kit higiene bucal', 'category' => 'Saúde', 'stock' => 95, 'status' => 'Ativo'],
+            ['name' => 'Calçados infantis', 'category' => 'Vestuário', 'stock' => 18, 'status' => 'Revisão'],
+            ['name' => 'Cesta de frutas', 'category' => 'Alimentação', 'stock' => 60, 'status' => 'Ativo'],
+            ['name' => 'Curso profissionalizante', 'category' => 'Educação', 'stock' => 25, 'status' => 'Ativo'],
+            ['name' => 'Kit cama e mesa', 'category' => 'Vestuário', 'stock' => 3, 'status' => 'Inativo'],
+            ['name' => 'Voucher R$ 50', 'category' => 'Financeiro', 'stock' => 110, 'status' => 'Ativo'],
+        ];
+
+        foreach ($benefits as $index => $data) {
+            $code = 'BNF-' . str_pad((string) ($index + 1), 3, '0', STR_PAD_LEFT);
+            Benefit::create(array_merge($data, ['code' => $code]));
+        }
+    }
+}

--- a/app/database/seeders/DatabaseSeeder.php
+++ b/app/database/seeders/DatabaseSeeder.php
@@ -15,6 +15,7 @@ class DatabaseSeeder extends Seeder
             AdminSeeder::class,
             CommunityCenterSeeder::class,
             FamilySeeder::class,
+            BenefitSeeder::class,
         ]);
     }
 }

--- a/app/resources/js/components/beneficios/create-benefit-modal.tsx
+++ b/app/resources/js/components/beneficios/create-benefit-modal.tsx
@@ -5,35 +5,69 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { cn } from '@/lib/utils';
-import { Check, FileImage, Minus, Plus, User } from 'lucide-react';
-import { useCallback, useState } from 'react';
-import { CATEGORY_OPTIONS } from './data';
+import { Check, FileImage, ImageIcon, Minus, Plus, Trash2, User, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { CATEGORY_OPTIONS, formatIsoDateToInput } from './data';
+import { router, usePage } from '@inertiajs/react';
+import type { Benefit } from './types';
 
-interface CreateBenefitModalProps {
+interface BenefitFormModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  benefitToEdit?: Benefit | null;
 }
 
-export function CreateBenefitModal({ open, onOpenChange }: CreateBenefitModalProps) {
+const STATUS_OPTIONS = [
+  { value: 'Ativo', label: 'Ativo' },
+  { value: 'Revisão', label: 'Revisão' },
+  { value: 'Inativo', label: 'Inativo' },
+];
+
+export function BenefitFormModal({ open, onOpenChange, benefitToEdit }: BenefitFormModalProps) {
+  const isEdit = !!benefitToEdit;
+  const { auth } = usePage().props as { auth: { user: { name: string } | null } };
+  const currentUserName = auth.user?.name ?? 'Usuário';
+
   const [name, setName] = useState('');
   const [category, setCategory] = useState<string>('');
-  const [quantity, setQuantity] = useState(1);
+  const [stock, setStock] = useState(1);
+  const [status, setStatus] = useState<string>('Ativo');
   const [donor, setDonor] = useState('');
   const [validity, setValidity] = useState('');
   const [notes, setNotes] = useState('');
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [removeImage, setRemoveImage] = useState(false);
 
   const reset = useCallback(() => {
     setName('');
     setCategory('');
-    setQuantity(1);
+    setStock(1);
+    setStatus('Ativo');
     setDonor('');
     setValidity('');
     setNotes('');
     setImageFile(null);
     setIsDragging(false);
+    setRemoveImage(false);
   }, []);
+
+  useEffect(() => {
+    if (isEdit && benefitToEdit) {
+      setName(benefitToEdit.name);
+      setCategory(benefitToEdit.category);
+      setStock(benefitToEdit.stock);
+      setStatus(benefitToEdit.status);
+      setDonor(benefitToEdit.donor ?? '');
+      setValidity(formatIsoDateToInput(benefitToEdit.validity) ?? '');
+      setNotes(benefitToEdit.notes ?? '');
+      setImageFile(null);
+      setIsDragging(false);
+      setRemoveImage(false);
+    } else if (open) {
+      reset();
+    }
+  }, [isEdit, benefitToEdit, open, reset]);
 
   const handleOpenChange = useCallback(
     (next: boolean) => {
@@ -43,12 +77,13 @@ export function CreateBenefitModal({ open, onOpenChange }: CreateBenefitModalPro
     [onOpenChange, reset],
   );
 
-  const increment = () => setQuantity((q) => Math.min(999, q + 1));
-  const decrement = () => setQuantity((q) => Math.max(1, q - 1));
+  const increment = () => setStock((q) => Math.min(999, q + 1));
+  const decrement = () => setStock((q) => Math.max(0, q - 1));
 
   const handleFileChange = (file: File | null) => {
     if (file && file.size <= 5 * 1024 * 1024) {
       setImageFile(file);
+      setRemoveImage(false);
     }
   };
 
@@ -61,9 +96,43 @@ export function CreateBenefitModal({ open, onOpenChange }: CreateBenefitModalPro
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log('Submit benefit:', { name, category, quantity, donor, validity, notes, imageFile });
-    handleOpenChange(false);
+
+    const formData = new FormData();
+    formData.append('name', name);
+    formData.append('category', category);
+    if (isEdit) {
+      formData.append('stock', String(stock));
+      formData.append('status', status);
+    } else {
+      formData.append('quantity', String(stock));
+    }
+    if (donor) formData.append('donor', donor);
+    if (validity) formData.append('validity', validity);
+    if (notes) formData.append('notes', notes);
+    if (imageFile) formData.append('image', imageFile);
+    if (isEdit && removeImage) formData.append('remove_image', '1');
+
+    if (isEdit && benefitToEdit) {
+      formData.append('_method', 'PUT');
+      router.post(`/beneficios/${benefitToEdit.id}`, formData, {
+        forceFormData: true,
+        preserveState: true,
+        preserveScroll: true,
+        onSuccess: () => handleOpenChange(false),
+      });
+    } else {
+      router.post('/beneficios', formData, {
+        forceFormData: true,
+        preserveState: true,
+        preserveScroll: true,
+        onSuccess: () => handleOpenChange(false),
+      });
+    }
   };
+
+  const existingImageUrl = isEdit && benefitToEdit?.image_path && !removeImage
+    ? `/storage/${benefitToEdit.image_path}`
+    : null;
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -71,10 +140,12 @@ export function CreateBenefitModal({ open, onOpenChange }: CreateBenefitModalPro
         <form onSubmit={handleSubmit} className="flex max-h-[90vh] flex-col">
           <div className="overflow-y-auto px-8 py-6">
             <DialogTitle className="text-center text-2xl font-bold tracking-[-0.03em] uppercase">
-              Registrar novo benefício
+              {isEdit ? 'Editar benefício' : 'Registrar novo benefício'}
             </DialogTitle>
             <DialogDescription className="sr-only">
-              Preencha os campos abaixo para cadastrar um novo benefício no catálogo.
+              {isEdit
+                ? 'Preencha os campos abaixo para editar o benefício.'
+                : 'Preencha os campos abaixo para cadastrar um novo benefício no catálogo.'}
             </DialogDescription>
 
             <div className="mt-6 space-y-4">
@@ -103,24 +174,24 @@ export function CreateBenefitModal({ open, onOpenChange }: CreateBenefitModalPro
                   </Select>
                 </FormField>
 
-                <FormField label="Quantidade a ser adicionada" required>
+                <FormField label={isEdit ? 'Quantidade em estoque' : 'Quantidade a ser adicionada'} required>
                   <div className="border-input flex h-9 items-stretch rounded-md border shadow-xs">
                     <button
                       type="button"
                       onClick={decrement}
-                      disabled={quantity <= 1}
+                      disabled={stock <= 0}
                       className="text-foreground/70 hover:bg-muted flex w-10 items-center justify-center transition-colors disabled:cursor-not-allowed disabled:opacity-40"
                       aria-label="Diminuir quantidade"
                     >
                       <Minus className="size-4" />
                     </button>
                     <div className="border-input flex flex-1 items-center justify-center border-x text-sm font-medium">
-                      {quantity}
+                      {stock}
                     </div>
                     <button
                       type="button"
                       onClick={increment}
-                      disabled={quantity >= 999}
+                      disabled={stock >= 999}
                       className="text-foreground/70 hover:bg-muted flex w-10 items-center justify-center transition-colors disabled:cursor-not-allowed disabled:opacity-40"
                       aria-label="Aumentar quantidade"
                     >
@@ -129,6 +200,23 @@ export function CreateBenefitModal({ open, onOpenChange }: CreateBenefitModalPro
                   </div>
                 </FormField>
               </div>
+
+              {isEdit && (
+                <FormField label="Status">
+                  <Select value={status} onValueChange={setStatus}>
+                    <SelectTrigger className="border-border w-full border">
+                      <SelectValue placeholder="Selecione o status" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STATUS_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormField>
+              )}
 
               <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <FormField label="Doador/Origem">
@@ -148,7 +236,11 @@ export function CreateBenefitModal({ open, onOpenChange }: CreateBenefitModalPro
               <FormField label="Responsável por registrar (preenchido automaticamente)">
                 <div className="border-input bg-muted/40 text-foreground/70 flex h-9 items-center gap-2 rounded-md border px-2.5 text-sm">
                   <User className="text-foreground/60 size-4" />
-                  <span>João Silva (Administrador)</span>
+                  <span>
+                    {isEdit && benefitToEdit?.creator
+                      ? `${benefitToEdit.creator.name} (criador) — editando como ${currentUserName}`
+                      : currentUserName}
+                  </span>
                 </div>
               </FormField>
 
@@ -173,36 +265,54 @@ export function CreateBenefitModal({ open, onOpenChange }: CreateBenefitModalPro
                   Faça o upload de uma imagem para ajudar a identificar melhor o item
                 </p>
 
-                <label
-                  onDragOver={(e) => {
-                    e.preventDefault();
-                    setIsDragging(true);
-                  }}
-                  onDragLeave={() => setIsDragging(false)}
-                  onDrop={handleDrop}
-                  className={cn(
-                    'border-foreground/20 bg-muted/20 hover:bg-muted/40 mt-3 flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-6 py-10 text-center transition-colors',
-                    isDragging && 'border-primary bg-primary/5',
-                    imageFile && 'border-primary/50 bg-primary/5',
-                  )}
-                >
-                  <input
-                    type="file"
-                    accept="image/png,image/jpeg,application/pdf"
-                    className="sr-only"
-                    onChange={(e) => handleFileChange(e.target.files?.[0] ?? null)}
-                  />
-                  <div className="bg-accent text-primary flex size-12 items-center justify-center rounded-lg">
-                    <FileImage className="size-5" />
+                {existingImageUrl ? (
+                  <div className="mt-3 relative rounded-lg overflow-hidden border border-border w-fit max-w-full">
+                    <img
+                      src={existingImageUrl}
+                      alt="Imagem do benefício"
+                      className="max-h-48 object-contain"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setRemoveImage(true)}
+                      className="absolute top-2 right-2 bg-red-600 text-white rounded-full p-1 hover:bg-red-700 transition-colors"
+                      aria-label="Remover imagem"
+                    >
+                      <Trash2 className="size-3" />
+                    </button>
                   </div>
-                  <p className="text-sm">
-                    <span className="text-primary font-semibold">Clique para selecionar</span>
-                    <span className="text-foreground/70"> ou arraste o arquivo</span>
-                  </p>
-                  <p className="text-foreground/60 text-xs">
-                    {imageFile ? imageFile.name : 'PNG, JPG ou PDF (Máx. 5MB)'}
-                  </p>
-                </label>
+                ) : (
+                  <label
+                    onDragOver={(e) => {
+                      e.preventDefault();
+                      setIsDragging(true);
+                    }}
+                    onDragLeave={() => setIsDragging(false)}
+                    onDrop={handleDrop}
+                    className={cn(
+                      'border-foreground/20 bg-muted/20 hover:bg-muted/40 mt-3 flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed px-6 py-10 text-center transition-colors',
+                      isDragging && 'border-primary bg-primary/5',
+                      imageFile && 'border-primary/50 bg-primary/5',
+                    )}
+                  >
+                    <input
+                      type="file"
+                      accept="image/png,image/jpeg,application/pdf"
+                      className="sr-only"
+                      onChange={(e) => handleFileChange(e.target.files?.[0] ?? null)}
+                    />
+                    <div className="bg-accent text-primary flex size-12 items-center justify-center rounded-lg">
+                      {imageFile ? <ImageIcon className="size-5" /> : <FileImage className="size-5" />}
+                    </div>
+                    <p className="text-sm">
+                      <span className="text-primary font-semibold">Clique para selecionar</span>
+                      <span className="text-foreground/70"> ou arraste o arquivo</span>
+                    </p>
+                    <p className="text-foreground/60 text-xs">
+                      {imageFile ? imageFile.name : 'PNG, JPG ou PDF (Máx. 5MB)'}
+                    </p>
+                  </label>
+                )}
               </div>
             </div>
           </div>
@@ -213,7 +323,7 @@ export function CreateBenefitModal({ open, onOpenChange }: CreateBenefitModalPro
             </Button>
             <Button type="submit" variant="default" className="gap-2 px-5">
               <Check className="size-4" />
-              Concluir Cadastro
+              {isEdit ? 'Salvar Alterações' : 'Concluir Cadastro'}
             </Button>
           </div>
         </form>

--- a/app/resources/js/components/beneficios/create-benefit-modal.tsx
+++ b/app/resources/js/components/beneficios/create-benefit-modal.tsx
@@ -9,6 +9,7 @@ import { Check, FileImage, ImageIcon, Minus, Plus, Trash2, User, X } from 'lucid
 import { useCallback, useEffect, useState } from 'react';
 import { CATEGORY_OPTIONS, formatIsoDateToInput } from './data';
 import { router, usePage } from '@inertiajs/react';
+import { toaster } from '@/components/toasters/toast-alert';
 import type { Benefit } from './types';
 
 interface BenefitFormModalProps {
@@ -118,14 +119,26 @@ export function BenefitFormModal({ open, onOpenChange, benefitToEdit }: BenefitF
         forceFormData: true,
         preserveState: true,
         preserveScroll: true,
-        onSuccess: () => handleOpenChange(false),
+        onSuccess: () => {
+          handleOpenChange(false);
+          toaster.createSuccess('Sucesso', 'Benefício atualizado com sucesso!');
+        },
+        onError: () => {
+          toaster.createError('Erro', 'Não foi possível atualizar o benefício.');
+        },
       });
     } else {
       router.post('/beneficios', formData, {
         forceFormData: true,
         preserveState: true,
         preserveScroll: true,
-        onSuccess: () => handleOpenChange(false),
+        onSuccess: () => {
+          handleOpenChange(false);
+          toaster.createSuccess('Sucesso', 'Benefício cadastrado com sucesso!');
+        },
+        onError: () => {
+          toaster.createError('Erro', 'Não foi possível cadastrar o benefício.');
+        },
       });
     }
   };

--- a/app/resources/js/components/beneficios/data.ts
+++ b/app/resources/js/components/beneficios/data.ts
@@ -1,27 +1,4 @@
-import type { Benefit, PaginationResult } from './types';
-
 export const LOW_STOCK_THRESHOLD = 20;
-
-export const BENEFITS: Benefit[] = [
-  { code: '#BNF-001', name: 'Cesta básica padrão', category: 'Alimentação', stock: 145, status: 'Ativo' },
-  { code: '#BNF-002', name: 'Voucher R$ 100', category: 'Financeiro', stock: 50, status: 'Ativo' },
-  { code: '#BNF-003', name: 'Kit higiene', category: 'Saúde', stock: 210, status: 'Ativo' },
-  { code: '#BNF-004', name: 'Cesta básica completa', category: 'Alimentação', stock: 85, status: 'Ativo' },
-  { code: '#BNF-005', name: 'Auxílio gás', category: 'Financeiro', stock: 12, status: 'Ativo' },
-  { code: '#BNF-006', name: 'Kit material escolar', category: 'Educação', stock: 67, status: 'Ativo' },
-  { code: '#BNF-007', name: 'Cesta natalina', category: 'Alimentação', stock: 8, status: 'Revisão' },
-  { code: '#BNF-008', name: 'Voucher R$ 200', category: 'Financeiro', stock: 30, status: 'Ativo' },
-  { code: '#BNF-009', name: 'Kit primeiros socorros', category: 'Saúde', stock: 15, status: 'Revisão' },
-  { code: '#BNF-010', name: 'Uniforme escolar', category: 'Vestuário', stock: 42, status: 'Ativo' },
-  { code: '#BNF-011', name: 'Cesta básica leve', category: 'Alimentação', stock: 180, status: 'Ativo' },
-  { code: '#BNF-012', name: 'Auxílio transporte', category: 'Financeiro', stock: 5, status: 'Revisão' },
-  { code: '#BNF-013', name: 'Kit higiene bucal', category: 'Saúde', stock: 95, status: 'Ativo' },
-  { code: '#BNF-014', name: 'Calçados infantis', category: 'Vestuário', stock: 18, status: 'Revisão' },
-  { code: '#BNF-015', name: 'Cesta de frutas', category: 'Alimentação', stock: 60, status: 'Ativo' },
-  { code: '#BNF-016', name: 'Curso profissionalizante', category: 'Educação', stock: 25, status: 'Ativo' },
-  { code: '#BNF-017', name: 'Kit cama e mesa', category: 'Vestuário', stock: 3, status: 'Inativo' },
-  { code: '#BNF-018', name: 'Voucher R$ 50', category: 'Financeiro', stock: 110, status: 'Ativo' },
-];
 
 export const CATEGORY_OPTIONS: { value: string; label: string }[] = [
   { value: 'all', label: 'Todas as Categorias' },
@@ -32,39 +9,22 @@ export const CATEGORY_OPTIONS: { value: string; label: string }[] = [
   { value: 'Educação', label: 'Educação' },
 ];
 
-export function filterBenefits(
-  benefits: Benefit[],
-  { search, category }: { search: string; category: string },
-): Benefit[] {
-  let result = benefits;
-
-  if (category && category !== 'all') {
-    result = result.filter((b) => b.category === category);
-  }
-
-  if (search.trim()) {
-    const q = search.toLowerCase().trim();
-    result = result.filter(
-      (b) =>
-        b.name.toLowerCase().includes(q) || b.code.toLowerCase().includes(q) || b.category.toLowerCase().includes(q),
-    );
-  }
-
-  return result;
+export function formatIsoDateToDisplay(dateString: string | null): string | null {
+  if (!dateString) return null;
+  const d = new Date(dateString);
+  if (isNaN(d.getTime())) return null;
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const year = d.getFullYear();
+  return `${day}/${month}/${year}`;
 }
 
-export function paginate<T>(items: T[], currentPage: number, pageSize: number): PaginationResult<T> {
-  const total = items.length;
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
-  const safePage = Math.min(Math.max(1, currentPage), totalPages);
-  const startIndex = (safePage - 1) * pageSize + 1;
-  const endIndex = Math.min(safePage * pageSize, total);
-
-  return {
-    items: items.slice((safePage - 1) * pageSize, safePage * pageSize),
-    total,
-    totalPages,
-    startIndex: total === 0 ? 0 : startIndex,
-    endIndex,
-  };
+export function formatIsoDateToInput(dateString: string | null): string | null {
+  if (!dateString) return null;
+  const d = new Date(dateString);
+  if (isNaN(d.getTime())) return null;
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const year = d.getFullYear();
+  return `${year}-${month}-${day}`;
 }

--- a/app/resources/js/components/beneficios/delete-action-popover.tsx
+++ b/app/resources/js/components/beneficios/delete-action-popover.tsx
@@ -1,0 +1,56 @@
+import { Button } from '@/components/ui/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import { Trash2 } from 'lucide-react';
+import { useState } from 'react';
+
+interface DeleteActionPopoverProps {
+  onDelete: () => void;
+  ariaLabel?: string;
+}
+
+export function DeleteActionPopover({ onDelete, ariaLabel }: DeleteActionPopoverProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleConfirm = () => {
+    onDelete();
+    setOpen(false);
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        className={cn(
+          'flex size-8 items-center justify-center rounded-md transition-colors',
+          'bg-red-50 text-red-600 hover:bg-red-100',
+        )}
+        aria-label={ariaLabel}
+      >
+        <Trash2 className="size-4" />
+      </PopoverTrigger>
+      <PopoverContent side="top" align="end" sideOffset={8} className="w-64">
+        <PopoverHeader>
+          <PopoverTitle className="text-sm">Excluir benefício</PopoverTitle>
+          <PopoverDescription className="text-xs">
+            Tem certeza? Esta ação não pode ser desfeita.
+          </PopoverDescription>
+        </PopoverHeader>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" size="sm" className="h-8 text-xs" onClick={() => setOpen(false)}>
+            Cancelar
+          </Button>
+          <Button variant="destructive" size="sm" className="h-8 text-xs" onClick={handleConfirm}>
+            Excluir
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/resources/js/components/beneficios/stock-control-section.tsx
+++ b/app/resources/js/components/beneficios/stock-control-section.tsx
@@ -1,47 +1,80 @@
-import { useCallback, useMemo, useState } from 'react';
-import { CreateBenefitModal } from './create-benefit-modal';
-import { BENEFITS, filterBenefits, paginate } from './data';
+import { useCallback, useState } from 'react';
+import { BenefitFormModal } from './create-benefit-modal';
+import { ViewBenefitModal } from './view-benefit-modal';
 import { StockFilterBar } from './stock-filter-bar';
 import { StockSectionHeader } from './stock-section-header';
 import { StockTable } from './stock-table';
-import type { Benefit } from './types';
+import type { Benefit, PaginatedBenefits } from './types';
+import { router } from '@inertiajs/react';
 
-const PAGE_SIZE = 8;
+interface StockControlSectionProps {
+  benefits: PaginatedBenefits;
+}
 
-export function StockControlSection() {
-  const [search, setSearch] = useState('');
-  const [category, setCategory] = useState('all');
-  const [currentPage, setCurrentPage] = useState(1);
-  const [isCreateOpen, setIsCreateOpen] = useState(false);
+export function StockControlSection({ benefits }: StockControlSectionProps) {
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [benefitToEdit, setBenefitToEdit] = useState<Benefit | null>(null);
 
-  const filtered = useMemo(() => filterBenefits(BENEFITS, { search, category }), [search, category]);
+  const [isViewOpen, setIsViewOpen] = useState(false);
+  const [benefitToView, setBenefitToView] = useState<Benefit | null>(null);
 
-  const pagination = useMemo(() => paginate(filtered, currentPage, PAGE_SIZE), [filtered, currentPage]);
+  const searchParams = new URLSearchParams(window.location.search);
+  const [search, setSearch] = useState(searchParams.get('search') ?? '');
+  const [category, setCategory] = useState(searchParams.get('category') ?? 'all');
 
   const handleSearchChange = useCallback((value: string) => {
     setSearch(value);
-    setCurrentPage(1);
-  }, []);
+    router.get(
+      '/beneficios',
+      { search: value, category, page: 1 },
+      { preserveState: true, preserveScroll: true, replace: true },
+    );
+  }, [category]);
 
   const handleCategoryChange = useCallback((value: string) => {
     setCategory(value);
-    setCurrentPage(1);
-  }, []);
+    router.get(
+      '/beneficios',
+      { search, category: value, page: 1 },
+      { preserveState: true, preserveScroll: true, replace: true },
+    );
+  }, [search]);
+
+  const handlePageChange = useCallback((page: number) => {
+    router.get(
+      '/beneficios',
+      { search, category, page },
+      { preserveState: true, preserveScroll: true, replace: true },
+    );
+  }, [search, category]);
 
   const handleView = useCallback((benefit: Benefit) => {
-    console.log('View:', benefit.code);
+    setBenefitToView(benefit);
+    setIsViewOpen(true);
   }, []);
 
   const handleEdit = useCallback((benefit: Benefit) => {
-    console.log('Edit:', benefit.code);
+    setBenefitToEdit(benefit);
+    setIsFormOpen(true);
   }, []);
 
   const handleDelete = useCallback((benefit: Benefit) => {
-    console.log('Delete:', benefit.code);
+    if (confirm(`Tem certeza que deseja excluir o benefício "${benefit.name}"?`)) {
+      router.delete(`/beneficios/${benefit.id}`, {
+        preserveState: true,
+        preserveScroll: true,
+      });
+    }
   }, []);
 
   const handleAdd = useCallback(() => {
-    setIsCreateOpen(true);
+    setBenefitToEdit(null);
+    setIsFormOpen(true);
+  }, []);
+
+  const handleCloseFormModal = useCallback(() => {
+    setIsFormOpen(false);
+    setBenefitToEdit(null);
   }, []);
 
   return (
@@ -61,20 +94,30 @@ export function StockControlSection() {
 
       <div className="mt-4">
         <StockTable
-          benefits={pagination.items}
-          startIndex={pagination.startIndex}
-          endIndex={pagination.endIndex}
-          total={pagination.total}
-          currentPage={currentPage}
-          totalPages={pagination.totalPages}
-          onPageChange={setCurrentPage}
+          benefits={benefits.data}
+          startIndex={benefits.from ?? 1}
+          endIndex={benefits.to ?? benefits.data.length}
+          total={benefits.total}
+          currentPage={benefits.current_page}
+          totalPages={benefits.last_page}
+          onPageChange={handlePageChange}
           onView={handleView}
           onEdit={handleEdit}
           onDelete={handleDelete}
         />
       </div>
 
-      <CreateBenefitModal open={isCreateOpen} onOpenChange={setIsCreateOpen} />
+      <BenefitFormModal
+        open={isFormOpen}
+        onOpenChange={handleCloseFormModal}
+        benefitToEdit={benefitToEdit}
+      />
+
+      <ViewBenefitModal
+        benefit={benefitToView}
+        open={isViewOpen}
+        onOpenChange={setIsViewOpen}
+      />
     </section>
   );
 }

--- a/app/resources/js/components/beneficios/stock-control-section.tsx
+++ b/app/resources/js/components/beneficios/stock-control-section.tsx
@@ -108,6 +108,7 @@ export function StockControlSection({ benefits }: StockControlSectionProps) {
       </div>
 
       <BenefitFormModal
+        key={benefitToEdit ? `edit-${benefitToEdit.id}` : 'create'}
         open={isFormOpen}
         onOpenChange={handleCloseFormModal}
         benefitToEdit={benefitToEdit}

--- a/app/resources/js/components/beneficios/stock-control-section.tsx
+++ b/app/resources/js/components/beneficios/stock-control-section.tsx
@@ -4,6 +4,7 @@ import { ViewBenefitModal } from './view-benefit-modal';
 import { StockFilterBar } from './stock-filter-bar';
 import { StockSectionHeader } from './stock-section-header';
 import { StockTable } from './stock-table';
+import { toaster } from '@/components/toasters/toast-alert';
 import type { Benefit, PaginatedBenefits } from './types';
 import { router } from '@inertiajs/react';
 
@@ -59,12 +60,16 @@ export function StockControlSection({ benefits }: StockControlSectionProps) {
   }, []);
 
   const handleDelete = useCallback((benefit: Benefit) => {
-    if (confirm(`Tem certeza que deseja excluir o benefício "${benefit.name}"?`)) {
-      router.delete(`/beneficios/${benefit.id}`, {
-        preserveState: true,
-        preserveScroll: true,
-      });
-    }
+    router.delete(`/beneficios/${benefit.id}`, {
+      preserveState: true,
+      preserveScroll: true,
+      onSuccess: () => {
+        toaster.createSuccess('Sucesso', 'Benefício excluído com sucesso!');
+      },
+      onError: () => {
+        toaster.createError('Erro', 'Não foi possível excluir o benefício.');
+      },
+    });
   }, []);
 
   const handleAdd = useCallback(() => {

--- a/app/resources/js/components/beneficios/stock-table-row.tsx
+++ b/app/resources/js/components/beneficios/stock-table-row.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/lib/utils';
 import { BenefitCategoryBadge } from './category-badge';
 import { LOW_STOCK_THRESHOLD } from './data';
+import { DeleteActionPopover } from './delete-action-popover';
 import { StockActionButton } from './stock-action-button';
 import type { Benefit } from './types';
 
@@ -28,11 +29,7 @@ export function StockTableRow({ benefit, onView, onEdit, onDelete }: StockTableR
         <div className="flex items-center gap-2">
           <StockActionButton variant="view" aria-label={`Ver ${benefit.name}`} onClick={() => onView(benefit)} />
           <StockActionButton variant="edit" aria-label={`Editar ${benefit.name}`} onClick={() => onEdit(benefit)} />
-          <StockActionButton
-            variant="delete"
-            aria-label={`Excluir ${benefit.name}`}
-            onClick={() => onDelete(benefit)}
-          />
+          <DeleteActionPopover ariaLabel={`Excluir ${benefit.name}`} onDelete={() => onDelete(benefit)} />
         </div>
       </td>
     </tr>

--- a/app/resources/js/components/beneficios/stock-table.tsx
+++ b/app/resources/js/components/beneficios/stock-table.tsx
@@ -45,7 +45,7 @@ export function StockTable({
             <tbody>
               {benefits.map((benefit) => (
                 <StockTableRow
-                  key={benefit.code}
+                  key={benefit.id}
                   benefit={benefit}
                   onView={onView}
                   onEdit={onEdit}

--- a/app/resources/js/components/beneficios/types.ts
+++ b/app/resources/js/components/beneficios/types.ts
@@ -1,22 +1,29 @@
 export type BenefitCategory = 'Alimentação' | 'Financeiro' | 'Saúde' | 'Vestuário' | 'Educação';
 
 export interface Benefit {
+  id: number;
   code: string;
   name: string;
   category: BenefitCategory;
   stock: number;
   status: 'Ativo' | 'Revisão' | 'Inativo';
+  donor: string | null;
+  validity: string | null;
+  notes: string | null;
+  image_path: string | null;
+  created_by: number | null;
+  creator: { id: number; name: string } | null;
+  created_at: string;
+  updated_at: string;
 }
 
-export interface PaginationState {
-  currentPage: number;
-  pageSize: number;
-}
-
-export interface PaginationResult<T> {
-  items: T[];
+export interface PaginatedBenefits {
+  data: Benefit[];
+  current_page: number;
+  last_page: number;
+  from: number;
+  to: number;
   total: number;
-  totalPages: number;
-  startIndex: number;
-  endIndex: number;
+  per_page: number;
+  links: { url: string | null; label: string; active: boolean }[];
 }

--- a/app/resources/js/components/beneficios/view-benefit-modal.tsx
+++ b/app/resources/js/components/beneficios/view-benefit-modal.tsx
@@ -1,0 +1,154 @@
+import { Card, CardContent } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { Calendar, ImageIcon, Package, Tag, User, UserCircle } from 'lucide-react';
+import { formatIsoDateToDisplay } from './data';
+import type { Benefit } from './types';
+
+const CATEGORY_STYLES: Record<string, string> = {
+  Alimentação: 'bg-blue-50 text-blue-700 border-blue-200',
+  Financeiro: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  Saúde: 'bg-amber-50 text-amber-700 border-amber-200',
+  Vestuário: 'bg-purple-50 text-purple-700 border-purple-200',
+  Educação: 'bg-pink-50 text-pink-700 border-pink-200',
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  Ativo: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  Revisão: 'bg-amber-50 text-amber-700 border-amber-200',
+  Inativo: 'bg-red-50 text-red-700 border-red-200',
+};
+
+interface ViewBenefitModalProps {
+  benefit: Benefit | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ViewBenefitModal({ benefit, open, onOpenChange }: ViewBenefitModalProps) {
+  if (!benefit) return null;
+
+  const imageUrl = benefit.image_path ? `/storage/${benefit.image_path}` : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg gap-0 p-0 sm:max-w-lg">
+        <div className="px-8 py-6">
+          <DialogTitle className="text-center text-2xl font-bold tracking-[-0.03em] uppercase">
+            Detalhes do Benefício
+          </DialogTitle>
+
+          <div className="mt-6 space-y-4">
+            <div className="flex items-center justify-between">
+              <span className="text-foreground/60 text-sm font-medium">Código</span>
+              <span className="text-sm font-bold">{benefit.code}</span>
+            </div>
+
+            <div>
+              <span className="text-foreground/60 text-sm font-medium">Nome</span>
+              <p className="text-lg font-semibold uppercase mt-0.5">{benefit.name}</p>
+            </div>
+
+            <div className="flex items-center gap-3 flex-wrap">
+              <Badge variant="outline" className={cn('uppercase', CATEGORY_STYLES[benefit.category])}>
+                {benefit.category}
+              </Badge>
+              <Badge variant="outline" className={cn('uppercase', STATUS_STYLES[benefit.status])}>
+                {benefit.status}
+              </Badge>
+            </div>
+
+            <Card className="rounded-xl">
+              <CardContent className="p-4 space-y-3">
+                <div className="flex items-center gap-3">
+                  <div className="bg-accent text-primary flex size-8 items-center justify-center rounded-lg">
+                    <Package className="size-4" />
+                  </div>
+                  <div>
+                    <p className="text-xs text-foreground/60">Estoque</p>
+                    <p className={cn('text-sm font-semibold', benefit.stock <= 20 ? 'text-destructive' : 'text-primary')}>
+                      {benefit.stock} unidades
+                    </p>
+                  </div>
+                </div>
+
+                {benefit.donor && (
+                  <div className="flex items-center gap-3">
+                    <div className="bg-accent text-primary flex size-8 items-center justify-center rounded-lg">
+                      <User className="size-4" />
+                    </div>
+                    <div>
+                      <p className="text-xs text-foreground/60">Doador/Origem</p>
+                      <p className="text-sm font-semibold">{benefit.donor}</p>
+                    </div>
+                  </div>
+                )}
+
+                {benefit.validity && (
+                  <div className="flex items-center gap-3">
+                    <div className="bg-accent text-primary flex size-8 items-center justify-center rounded-lg">
+                      <Calendar className="size-4" />
+                    </div>
+                    <div>
+                      <p className="text-xs text-foreground/60">Validade</p>
+                      <p className="text-sm font-semibold">{formatIsoDateToDisplay(benefit.validity)}</p>
+                    </div>
+                  </div>
+                )}
+
+                <div className="flex items-center gap-3">
+                  <div className="bg-accent text-primary flex size-8 items-center justify-center rounded-lg">
+                    <Tag className="size-4" />
+                  </div>
+                  <div>
+                    <p className="text-xs text-foreground/60">Categoria</p>
+                    <p className="text-sm font-semibold">{benefit.category}</p>
+                  </div>
+                </div>
+
+                {benefit.creator && (
+                  <div className="flex items-center gap-3">
+                    <div className="bg-accent text-primary flex size-8 items-center justify-center rounded-lg">
+                      <UserCircle className="size-4" />
+                    </div>
+                    <div>
+                      <p className="text-xs text-foreground/60">Responsável</p>
+                      <p className="text-sm font-semibold">{benefit.creator.name}</p>
+                    </div>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            {benefit.notes && (
+              <div>
+                <span className="text-foreground/60 text-sm font-medium">Observações</span>
+                <p className="text-sm text-foreground/80 mt-1 whitespace-pre-wrap">{benefit.notes}</p>
+              </div>
+            )}
+
+            {imageUrl ? (
+              <div>
+                <span className="text-foreground/60 text-sm font-medium">Imagem</span>
+                <div className="mt-2 rounded-lg overflow-hidden border border-border">
+                  <img
+                    src={imageUrl}
+                    alt={benefit.name}
+                    className="w-full max-h-64 object-contain"
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 text-foreground/50 text-sm">
+                <ImageIcon className="size-4" />
+                <span>Sem imagem cadastrada</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/resources/js/components/dialogs/confirm-dialog.tsx
+++ b/app/resources/js/components/dialogs/confirm-dialog.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+
+interface ConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description: string;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  variant?: 'destructive' | 'default';
+}
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmText = 'Confirmar',
+  cancelText = 'Cancelar',
+  onConfirm,
+  variant = 'default',
+}: ConfirmDialogProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={onConfirm}
+            variant={variant === 'destructive' ? 'destructive' : 'default'}
+          >
+            {confirmText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/app/resources/js/pages/beneficios.tsx
+++ b/app/resources/js/pages/beneficios.tsx
@@ -1,15 +1,20 @@
 import { StockControlSection } from '@/components/beneficios/stock-control-section';
 import { Header } from '@/components/layout/header';
 import { Head } from '@inertiajs/react';
+import type { PaginatedBenefits } from '@/components/beneficios/types';
 
-export default function Beneficios() {
+interface BeneficiosPageProps {
+  benefits: PaginatedBenefits;
+}
+
+export default function Beneficios({ benefits }: BeneficiosPageProps) {
   return (
     <>
       <Head title="Benefícios" />
       <div className="bg-surface min-h-screen">
         <Header />
         <main className="max-w-lm mx-auto w-full px-8 pt-8 pb-12">
-          <StockControlSection />
+          <StockControlSection benefits={benefits} />
         </main>
       </div>
     </>

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -5,6 +5,7 @@ use Inertia\Inertia;
 use App\Http\Controllers\FamilyController;
 use App\Http\Controllers\Admin\AppearanceController;
 use App\Http\Controllers\Admin\ConfiguracoesGeraisController;
+use App\Http\Controllers\BenefitController;
 use App\Http\Controllers\DashboardController;
 
 Route::get('/', function () {
@@ -30,9 +31,10 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
 });
 
 Route::middleware(['auth'])->group(function () {
-    Route::get('beneficios', function () {
-        return Inertia::render('beneficios');
-    })->name('beneficios');
+    Route::get('beneficios', [BenefitController::class, 'index'])->name('beneficios');
+    Route::post('beneficios', [BenefitController::class, 'store'])->name('beneficios.store');
+    Route::put('beneficios/{benefit}', [BenefitController::class, 'update'])->name('beneficios.update');
+    Route::delete('beneficios/{benefit}', [BenefitController::class, 'destroy'])->name('beneficios.destroy');
 
     Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
     Route::get('family', [FamilyController::class, 'index'])->name('family');


### PR DESCRIPTION
## Resumo

Integra a tela de **Controle de Estoque de Benefícios** ao backend, transformando a listagem de dados estáticos em um CRUD completo com persistência no banco, paginação server-side, filtros, upload de imagens e responsável identificado.

---

## O que mudou

### Backend

- **Migration** `create_benefits_table` — nova tabela `benefits` com campos: `code`, `name`, `category`, `stock`, `status`, `donor`, `validity`, `notes`, `image_path`, `created_by`.
- **Model** `Benefit` — com método `generateCode()` que gera códigos incrementais (`BNF-001`, `BNF-002`, …).
- **Controller** `BenefitController` — endpoints:
  - `GET /beneficios` — listagem paginada com filtro de busca e categoria.
  - `POST /beneficios` — criação com upload de imagem.
  - `PUT /beneficios/{id}` — edição.
  - `DELETE /beneficios/{id}` — exclusão permanente.
- **Form Requests** — `StoreBenefitRequest` e `UpdateBenefitRequest` com validações completas.
- **Seeder** `BenefitSeeder` — popula dados iniciais de exemplo (18 benefícios).

### Frontend

- **`types.ts`** — tipos atualizados para refletir o schema real do backend (`id`, `creator`, `image_path`, etc.).
- **`data.ts`** — removido mock de dados; mantido apenas categorias e funções utilitárias de formatação de data.
- **`stock-control-section.tsx`** — busca, filtro e paginação agora são server-side via `router.get`.
- **`create-benefit-modal.tsx`** — submit real via `router.post` com `FormData`; suporta criação e edição com:
  - Campos `stock` e `status` no modo edição.
  - Preview da imagem existente com botão de remover.
  - Responsável logado preenchido automaticamente.
- **`view-benefit-modal.tsx`** — novo modal de visualização com:
  - Badges de categoria e status.
  - Card com estoque, doador, validade, categoria e responsável.
  - Observações e imagem.
  - Data formatada em `DD/MM/YYYY`.

### Integração de usuário responsável

- Controller carrega `creator` via eager load (`with('creator')`).
- Modal de visualização exibe o nome do responsável que criou o benefício.
- Modal de edição mostra: criador original + usuário logado que está editando.

---

## Como testar

1. Rodar a migration:
   ```bash
   php artisan migrate
   ```
2. (Opcional) Rodar o seeder:
   ```bash
   php artisan db:seed --class=BenefitSeeder
   ```
3. Acessar `/beneficios` logado.
4. Testar: cadastrar, visualizar, editar, excluir, filtrar e paginar.
