### PR TITLE
Adicionar suporte a MinIO e refatorar upload de logo/favicon

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Variaveis de interpolacao do docker-compose (nao confundir com app/.env do Laravel).
+# Copie para .env na raiz e ajuste para seu ambiente de producao.
+
+# URL publica do app (sobrepoem APP_URL em docker-compose.prod.yml).
+APP_PUBLIC_URL=http://localhost
+
+# URL publica do MinIO acessivel pelo browser.
+# Em dev: http://localhost:9000/centelha
+# Em prod, aponte para o host publico do MinIO. Exemplos:
+#   - MinIO exposto direto:  http://minio.seudominio.com/centelha
+#   - Atras de reverse-proxy: https://seudominio.com/storage/centelha
+MINIO_PUBLIC_URL=http://localhost:9000/centelha

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Homestead.json
 Homestead.yaml
 Thumbs.db
 telas/
+.vite/

--- a/app/app/Console/Commands/MigrateDeliveryReceipts.php
+++ b/app/app/Console/Commands/MigrateDeliveryReceipts.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Delivery;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class MigrateDeliveryReceipts extends Command
+{
+    protected $signature = 'centelha:migrate-delivery-receipts';
+
+    protected $description = 'Migra comprovantes de entregas do disco public local para o MinIO (paths identicos, sem atualizar DB)';
+
+    public function handle(): int
+    {
+        $publicDisk = Storage::disk('public');
+        $minioDisk = Storage::disk('minio');
+
+        $deliveries = Delivery::whereNotNull('receipt_path')->get();
+
+        if ($deliveries->isEmpty()) {
+            $this->info('Nenhuma entrega com comprovante encontrada.');
+
+            return self::SUCCESS;
+        }
+
+        $migrated = 0;
+        $skipped = 0;
+
+        foreach ($deliveries as $delivery) {
+            $path = $delivery->receipt_path;
+
+            if ($minioDisk->exists($path)) {
+                $this->warn("Entrega #{$delivery->id}: comprovante já existe no MinIO ({$path}). Pulando.");
+                $skipped++;
+
+                continue;
+            }
+
+            if (! $publicDisk->exists($path)) {
+                $this->warn("Entrega #{$delivery->id}: arquivo não encontrado no disco public ({$path}). Pulando.");
+                $skipped++;
+
+                continue;
+            }
+
+            $minioDisk->put($path, $publicDisk->get($path));
+
+            $publicDisk->delete($path);
+
+            $migrated++;
+        }
+
+        $this->info("{$migrated} comprovante(s) migrado(s) com sucesso.");
+        $this->info("{$skipped} comprovante(s) pulado(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/app/Http/Controllers/Admin/ConfiguracoesGeraisController.php
+++ b/app/app/Http/Controllers/Admin/ConfiguracoesGeraisController.php
@@ -4,41 +4,59 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\CommunityCenter;
+use App\Services\StorageService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Redirect;
 
 class ConfiguracoesGeraisController extends Controller
 {
+    public function __construct(private readonly StorageService $storage) {}
+
     public function update(Request $request)
     {
         $validated = $request->validate([
-            'name'             => 'required|string|max:255',
-            'slogan'           => 'nullable|string|max:255',
-            'rodape_text'      => 'nullable|string',
-            'fontFamily'       => 'required|string',
-            'logo'             => 'nullable|image|mimes:svg,png,jpg,jpeg,gif|max:2048',
-            'favicon'          => 'nullable|image|mimes:png,jpg,jpeg,ico,svg|max:1024',
-            'social_links'     => 'nullable|json',
+            'name' => 'required|string|max:255',
+            'slogan' => 'nullable|string|max:255',
+            'rodape_text' => 'nullable|string',
+            'fontFamily' => 'required|string',
+            'logo' => 'nullable|image|mimes:svg,png,jpg,jpeg,gif|max:2048',
+            'favicon' => 'nullable|image|mimes:png,jpg,jpeg,ico,svg|max:1024',
+            'social_links' => 'nullable|json',
             'maintenance_mode' => 'boolean',
         ]);
 
         $center = CommunityCenter::firstOrCreate([]);
 
         $data = [
-            'name'             => $validated['name'],
-            'slogan'           => $validated['slogan'] ?? null,
-            'rodape_text'      => $validated['rodape_text'] ?? null,
-            'fontFamily'       => $validated['fontFamily'],
+            'name' => $validated['name'],
+            'slogan' => $validated['slogan'] ?? null,
+            'rodape_text' => $validated['rodape_text'] ?? null,
+            'fontFamily' => $validated['fontFamily'],
             'maintenance_mode' => $validated['maintenance_mode'] ?? false,
         ];
 
         if ($request->hasFile('logo')) {
-            $data['logo_path'] = $request->file('logo')->store('logos', 'public');
+            $data['logo_path'] = $this->storage->replace(
+                'public',
+                'logos',
+                $request->file('logo'),
+                $center->logo_path,
+            );
+        } elseif ($request->boolean('remove_logo')) {
+            $this->storage->delete('public', $center->logo_path);
+            $data['logo_path'] = null;
         }
 
         if ($request->hasFile('favicon')) {
-            $data['favicon_path'] = $request->file('favicon')->store('favicons', 'public');
+            $data['favicon_path'] = $this->storage->replace(
+                'public',
+                'favicons',
+                $request->file('favicon'),
+                $center->favicon_path,
+            );
+        } elseif ($request->boolean('remove_favicon')) {
+            $this->storage->delete('public', $center->favicon_path);
+            $data['favicon_path'] = null;
         }
 
         $center->update($data);

--- a/app/app/Http/Controllers/DeliveryController.php
+++ b/app/app/Http/Controllers/DeliveryController.php
@@ -247,14 +247,7 @@ class DeliveryController extends Controller
         $colors = $communityCenter?->colors ?? [];
         $primaryColor = $colors['primary'] ?? '#ff002e';
 
-        $logoPath = null;
-        if ($communityCenter?->logo_path) {
-            $logo = ltrim($communityCenter->logo_path, './');
-            $fullPath = public_path($logo);
-            if (file_exists($fullPath)) {
-                $logoPath = $fullPath;
-            }
-        }
+        $logoPath = $communityCenter?->logoFilePath();
 
         return [$communityCenter, $primaryColor, $logoPath];
     }

--- a/app/app/Models/CommunityCenter.php
+++ b/app/app/Models/CommunityCenter.php
@@ -2,11 +2,18 @@
 
 namespace App\Models;
 
+use App\Services\StorageService;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
 
 class CommunityCenter extends Model
 {
+    public const DEFAULT_LOGO_PATH = 'logo.svg';
+
+    public const DEFAULT_FAVICON_PATH = 'logo.png';
+
     protected $table = 'community_center';
+
     protected $fillable = [
         'name',
         'location',
@@ -19,6 +26,9 @@ class CommunityCenter extends Model
         'colors',
         'maintenance_mode',
     ];
+
+    protected $appends = ['logo_url', 'favicon_url'];
+
     protected function casts(): array
     {
         return [
@@ -31,5 +41,62 @@ class CommunityCenter extends Model
     public function socialLinks()
     {
         return $this->hasMany(SocialLink::class);
+    }
+
+    public function getLogoUrlAttribute(): string
+    {
+        return $this->resolveAssetUrl($this->logo_path, self::DEFAULT_LOGO_PATH);
+    }
+
+    public function getFaviconUrlAttribute(): string
+    {
+        return $this->resolveAssetUrl($this->favicon_path, self::DEFAULT_FAVICON_PATH);
+    }
+
+    public function logoFilePath(): ?string
+    {
+        return $this->resolveAssetFilePath($this->logo_path);
+    }
+
+    public function faviconFilePath(): ?string
+    {
+        return $this->resolveAssetFilePath($this->favicon_path);
+    }
+
+    private function resolveAssetUrl(?string $path, string $default): string
+    {
+        if (! $path) {
+            return asset($default);
+        }
+
+        if ($this->isStaticAssetPath($path)) {
+            return asset(ltrim($path, './'));
+        }
+
+        $url = app(StorageService::class)->url('public', $path);
+
+        return $url ?? asset($default);
+    }
+
+    private function resolveAssetFilePath(?string $path): ?string
+    {
+        if (! $path) {
+            return null;
+        }
+
+        if ($this->isStaticAssetPath($path)) {
+            $candidate = public_path(ltrim($path, './'));
+
+            return file_exists($candidate) ? $candidate : null;
+        }
+
+        $candidate = Storage::disk('public')->path($path);
+
+        return file_exists($candidate) ? $candidate : null;
+    }
+
+    private function isStaticAssetPath(string $path): bool
+    {
+        return str_starts_with($path, './') || ! str_contains($path, '/');
     }
 }

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace App\Providers;
 
+use App\Models\CommunityCenter;
 use App\Services\StorageService;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -20,6 +22,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        View::composer('app', function ($view) {
+            $view->with('communityCenter', CommunityCenter::first());
+        });
     }
 }

--- a/app/docker/nginx/default.conf
+++ b/app/docker/nginx/default.conf
@@ -11,7 +11,9 @@ server {
 
     location ~ \.php$ {
         include fastcgi_params;
-        fastcgi_pass php:9000;
+        resolver 127.0.0.11 valid=10s ipv6=off;
+        set $upstream php;
+        fastcgi_pass $upstream:9000;
         fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
         fastcgi_param DOCUMENT_ROOT $realpath_root;
         fastcgi_read_timeout 300;

--- a/app/docker/php/entrypoint.sh
+++ b/app/docker/php/entrypoint.sh
@@ -20,6 +20,8 @@ mkdir -p storage/framework/cache storage/framework/data storage/framework/views 
 chmod -R 775 storage bootstrap/cache || true
 chown -R www-data:www-data storage bootstrap/cache || true
 
+php artisan storage:link --relative=false --ansi || true
+
 if [ -n "${RUN_MIGRATIONS}" ]; then
   if [ "${APP_ENV}" = "production" ]; then
     php artisan migrate --force --ansi

--- a/app/docker/php/entrypoint.sh
+++ b/app/docker/php/entrypoint.sh
@@ -18,11 +18,10 @@ fi
 
 mkdir -p storage/framework/cache storage/framework/data storage/framework/views storage/logs bootstrap/cache
 chmod -R 775 storage bootstrap/cache || true
-chown -R www-data:www-data storage bootstrap/cache || true
 
 php artisan storage:link --relative=false --ansi || true
 
-if [ -n "${RUN_MIGRATIONS}" ]; then
+if [ "${RUN_MIGRATIONS}" = "1" ]; then
   if [ "${APP_ENV}" = "production" ]; then
     php artisan migrate --force --ansi
   else
@@ -30,7 +29,7 @@ if [ -n "${RUN_MIGRATIONS}" ]; then
   fi
 fi
 
-if [ -n "${RUN_SEEDERS}" ]; then
+if [ "${RUN_SEEDERS}" = "1" ]; then
   if [ "${APP_ENV}" = "production" ]; then
     php artisan db:seed --force --ansi
   else
@@ -38,8 +37,19 @@ if [ -n "${RUN_SEEDERS}" ]; then
   fi
 fi
 
+if [ ! -f public/build/manifest.json ] && [ ! -f public/build/hot ]; then
+  if [ -d node_modules ]; then
+    echo "[entrypoint] Vite manifest ausente e dev server inativo. Gerando build de fallback..."
+    npm run build --silent || echo "[entrypoint] AVISO: npm run build falhou. Inicie o serviço 'vite' para HMR."
+  else
+    echo "[entrypoint] AVISO: node_modules ausente. Inicie o serviço 'vite' (npm install) ou rode 'npm ci && npm run build'."
+  fi
+fi
+
 if [ -d /var/www/html/public.dist ] && [ ! -d /var/www/html/public/build ]; then
   cp -a /var/www/html/public.dist/* /var/www/html/public/
 fi
+
+chown -R www-data:www-data storage bootstrap/cache || true
 
 exec "$@"

--- a/app/resources/css/app.css
+++ b/app/resources/css/app.css
@@ -1,8 +1,8 @@
+@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap");
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 @import "@fontsource-variable/inter";
-@import url("https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap");
 
 @plugin 'tailwindcss-animate';
 

--- a/app/resources/js/components/entregas/create-delivery-modal.tsx
+++ b/app/resources/js/components/entregas/create-delivery-modal.tsx
@@ -234,7 +234,7 @@ export function CreateDeliveryModal({
   return (
     <Dialog onOpenChange={handleOpenChange} open={open}>
       <DialogContent
-        className="max-w-2xl gap-0 p-0 sm:max-w-2xl"
+        className="gap-0 p-0 md:max-w-2xl"
         showCloseButton={false}
       >
         <form className="flex max-h-[90vh] flex-col" onSubmit={handleSubmit}>

--- a/app/resources/js/components/entregas/create-delivery-modal.tsx
+++ b/app/resources/js/components/entregas/create-delivery-modal.tsx
@@ -60,7 +60,8 @@ export function CreateDeliveryModal({
   }
 
   const [beneficiarySearch, setBeneficiarySearch] = useState('')
-  const [selectedBeneficiaryId, setSelectedBeneficiaryId] = useState('')
+  const [selectedBeneficiary, setSelectedBeneficiary] =
+    useState<BeneficiaryOption | null>(null)
   const [beneficiaries, setBeneficiaries] = useState<BeneficiaryOption[]>([])
   const [showBeneficiaryList, setShowBeneficiaryList] = useState(false)
   const [benefitId, setBenefitId] = useState('')
@@ -76,7 +77,7 @@ export function CreateDeliveryModal({
 
   const reset = useCallback(() => {
     setBeneficiarySearch('')
-    setSelectedBeneficiaryId('')
+    setSelectedBeneficiary(null)
     setBeneficiaries([])
     setShowBeneficiaryList(false)
     setBenefitId('')
@@ -111,7 +112,7 @@ export function CreateDeliveryModal({
   }, [])
 
   useEffect(() => {
-    if (selectedBeneficiaryId || beneficiarySearch.length < 2) {
+    if (selectedBeneficiary || beneficiarySearch.length < 2) {
       setBeneficiaries([])
       return
     }
@@ -136,10 +137,10 @@ export function CreateDeliveryModal({
     }, 300)
 
     return () => clearTimeout(timer)
-  }, [beneficiarySearch, selectedBeneficiaryId])
+  }, [beneficiarySearch, selectedBeneficiary])
 
-  const selectedBeneficiaryLabel =
-    beneficiaries.find((b) => b.value === selectedBeneficiaryId)?.label ?? ''
+  const selectedBeneficiaryId = selectedBeneficiary?.value ?? ''
+  const selectedBeneficiaryLabel = selectedBeneficiary?.label ?? ''
 
   const increment = () => setQuantity((q) => Math.min(999, q + 1))
   const decrement = () => setQuantity((q) => Math.max(1, q - 1))
@@ -256,7 +257,7 @@ export function CreateDeliveryModal({
                   <Input
                     className="pl-9"
                     onChange={(e) => {
-                      setSelectedBeneficiaryId('')
+                      setSelectedBeneficiary(null)
                       setBeneficiarySearch(e.target.value)
                       setShowBeneficiaryList(true)
                     }}
@@ -272,7 +273,7 @@ export function CreateDeliveryModal({
                     <button
                       className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
                       onClick={() => {
-                        setSelectedBeneficiaryId('')
+                        setSelectedBeneficiary(null)
                         setBeneficiarySearch('')
                       }}
                       type="button"
@@ -281,7 +282,7 @@ export function CreateDeliveryModal({
                     </button>
                   ) : null}
 
-                  {showBeneficiaryList && !selectedBeneficiaryId && (
+                  {showBeneficiaryList && !selectedBeneficiary && (
                     <div className="absolute z-50 mt-1 max-h-56 w-full overflow-auto rounded-md border border-border bg-popover p-1 shadow-md">
                       {beneficiarySearch.length < 2 ? (
                         <p className="text-muted-foreground px-2 py-3 text-center text-sm">
@@ -301,8 +302,8 @@ export function CreateDeliveryModal({
                             key={b.value}
                             className="hover:bg-accent hover:text-accent-foreground w-full rounded-sm px-2 py-2 text-left text-sm"
                             onClick={() => {
-                              setSelectedBeneficiaryId(b.value)
-                              setBeneficiarySearch(b.label)
+                                setSelectedBeneficiary(b)
+                                setBeneficiarySearch(b.label)
                               setShowBeneficiaryList(false)
                             }}
                             type="button"
@@ -329,7 +330,13 @@ export function CreateDeliveryModal({
                 >
                   <Select onValueChange={setBenefitId} value={benefitId}>
                     <SelectTrigger className="border-border w-full border">
-                      <SelectValue placeholder="Selecione um tipo..." />
+                      <SelectValue placeholder="Selecione um tipo...">
+                        {benefitId
+                          ? (benefits.find(
+                              (b) => String(b.id) === benefitId,
+                            )?.name ?? null)
+                          : null}
+                      </SelectValue>
                     </SelectTrigger>
                     <SelectContent>
                       {benefits.map((option) => (

--- a/app/resources/js/components/gestao-sistema/forms/configs-gerais-form.tsx
+++ b/app/resources/js/components/gestao-sistema/forms/configs-gerais-form.tsx
@@ -37,12 +37,16 @@ const options = [
 interface ConfigsGeraisFormProps {
   onLogoChange?: (files: FileWithPreview[]) => void
   onFaviconChange?: (files: FileWithPreview[]) => void
+  currentLogoUrl?: string
+  currentFaviconUrl?: string
 }
 
 // Render
 export function ConfigsGeraisForm({
   onLogoChange,
   onFaviconChange,
+  currentLogoUrl,
+  currentFaviconUrl,
 }: ConfigsGeraisFormProps) {
   // Form Context
   const { control, register } = useFormContext()
@@ -71,13 +75,19 @@ export function ConfigsGeraisForm({
           >
             <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-5">
               <div className="md:col-span-3">
-                <Uploader2 onFilesChange={onLogoChange} />
+                <Uploader2
+                  currentLogoUrl={currentLogoUrl}
+                  onFilesChange={onLogoChange}
+                />
               </div>
               <div className="space-y-8 md:col-span-2">
                 <div className="space-y-2">
                   <Label>Ícone do Navegador (Favicon)</Label>
                   <div>
-                    <Uploader1 onFilesChange={onFaviconChange} />
+                    <Uploader1
+                      currentFaviconUrl={currentFaviconUrl}
+                      onFilesChange={onFaviconChange}
+                    />
                   </div>
                 </div>
                 <div className="space-y-2">

--- a/app/resources/js/components/inputs/uploader1.tsx
+++ b/app/resources/js/components/inputs/uploader1.tsx
@@ -7,8 +7,9 @@ import {
 
 interface Uploader1Props {
   onFilesChange?: (files: FileWithPreview[]) => void
+  currentFaviconUrl?: string
 }
-export default function Uploader1({ onFilesChange }: Uploader1Props) {
+export default function Uploader1({ onFilesChange, currentFaviconUrl }: Uploader1Props) {
   const [{ files }, { removeFile, openFileDialog, getInputProps }] =
     useFileUpload({
       accept: 'image/*',
@@ -37,7 +38,7 @@ export default function Uploader1({ onFilesChange }: Uploader1Props) {
             />
           ) : (
             <div aria-hidden="true" className="rounded-lg bg-zinc-200 py-1">
-              <img alt="Favicon atual" className="size-9" src="/logo.png" />
+              <img alt="Favicon atual" className="size-9" src={currentFaviconUrl ?? '/logo.png'} />
             </div>
           )}
         </div>

--- a/app/resources/js/components/inputs/uploader2.tsx
+++ b/app/resources/js/components/inputs/uploader2.tsx
@@ -14,8 +14,9 @@ import { Label } from '../ui/label'
 
 interface Uploader2Props {
   onFilesChange?: (files: FileWithPreview[]) => void
+  currentLogoUrl?: string
 }
-export default function Uploader2({ onFilesChange }: Uploader2Props) {
+export default function Uploader2({ onFilesChange, currentLogoUrl }: Uploader2Props) {
   const maxSize = convertMB(2)
   const [
     { files, isDragging, errors },
@@ -62,12 +63,22 @@ export default function Uploader2({ onFilesChange }: Uploader2Props) {
             </div>
           ) : (
             <div className="flex flex-col items-center justify-center px-4 py-3 text-center">
-              <div
-                aria-hidden="true"
-                className="mb-2 flex size-11 shrink-0 items-center justify-center bg-transparent"
-              >
-                <CloudUploadIcon className="size-8 opacity-60" />
-              </div>
+              {currentLogoUrl ? (
+                <div className="mb-2 flex h-11 shrink-0 items-center justify-center bg-transparent">
+                  <img
+                    alt="Logo atual"
+                    className="max-h-full max-w-full object-contain"
+                    src={currentLogoUrl}
+                  />
+                </div>
+              ) : (
+                <div
+                  aria-hidden="true"
+                  className="mb-2 flex size-11 shrink-0 items-center justify-center bg-transparent"
+                >
+                  <CloudUploadIcon className="size-8 opacity-60" />
+                </div>
+              )}
               <p className="mb-1.5 text-sm font-medium">
                 Arraste uma imagem ou clique para selecionar
               </p>

--- a/app/resources/js/components/usuarios/benefit-card.tsx
+++ b/app/resources/js/components/usuarios/benefit-card.tsx
@@ -1,0 +1,53 @@
+import { Pencil, Trash2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { BENEFIT_CATEGORY_STYLES } from './data'
+import type { Benefit } from './types'
+
+interface BenefitCardProps {
+  benefit: Benefit
+  onEdit: (benefit: Benefit) => void
+  onDelete: (benefit: Benefit) => void
+}
+
+export function BenefitCard({ benefit, onEdit, onDelete }: BenefitCardProps) {
+  const {
+    icon: Icon,
+    className,
+    label,
+  } = BENEFIT_CATEGORY_STYLES[benefit.category]
+
+  return (
+    <article className="border-border bg-card flex h-full flex-col rounded-2xl border p-5 shadow-sm transition-shadow hover:shadow-md">
+      <Badge
+        className={`w-fit gap-1.5 px-3 py-1 font-semibold ${className}`}
+        variant="outline"
+      >
+        <Icon className="size-3.5" />
+        {label}
+      </Badge>
+
+      <p className="text-foreground/80 mt-3 line-clamp-3 text-sm leading-relaxed">
+        {benefit.description}
+      </p>
+
+      <div className="border-border mt-auto flex items-center justify-end gap-2 border-t pt-4">
+        <button
+          aria-label={`Editar ${benefit.name}`}
+          className="bg-orange-50 text-orange-600 hover:bg-orange-100 flex size-8 items-center justify-center rounded-md transition-colors"
+          onClick={() => onEdit(benefit)}
+          type="button"
+        >
+          <Pencil className="size-4" />
+        </button>
+        <button
+          aria-label={`Excluir ${benefit.name}`}
+          className="bg-red-50 text-red-600 hover:bg-red-100 flex size-8 items-center justify-center rounded-md transition-colors"
+          onClick={() => onDelete(benefit)}
+          type="button"
+        >
+          <Trash2 className="size-4" />
+        </button>
+      </div>
+    </article>
+  )
+}

--- a/app/resources/js/components/usuarios/benefit-form-modal.tsx
+++ b/app/resources/js/components/usuarios/benefit-form-modal.tsx
@@ -1,0 +1,172 @@
+import { Check } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import type { Benefit, BenefitCategory } from './types'
+
+const CATEGORY_OPTIONS: { value: BenefitCategory; label: string }[] = [
+  { value: 'Alimentação', label: 'Alimentação' },
+  { value: 'Gás', label: 'Gás' },
+  { value: 'Higiene', label: 'Higiene' },
+  { value: 'Vestuário', label: 'Vestuário' },
+  { value: 'Educação', label: 'Educação' },
+  { value: 'Emergência', label: 'Emergência' },
+]
+
+interface BenefitFormModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  benefitToEdit?: Benefit | null
+  onSubmit: (data: {
+    name: string
+    category: BenefitCategory
+    description: string
+  }) => void
+}
+
+export function BenefitFormModal({
+  open,
+  onOpenChange,
+  benefitToEdit,
+  onSubmit,
+}: BenefitFormModalProps) {
+  const isEdit = !!benefitToEdit
+
+  const [name, setName] = useState('')
+  const [category, setCategory] = useState<BenefitCategory>('Alimentação')
+  const [description, setDescription] = useState('')
+
+  const reset = useCallback(() => {
+    setName('')
+    setCategory('Alimentação')
+    setDescription('')
+  }, [])
+
+  useEffect(() => {
+    if (isEdit && benefitToEdit) {
+      setName(benefitToEdit.name)
+      setCategory(benefitToEdit.category)
+      setDescription(benefitToEdit.description)
+    } else if (open) {
+      reset()
+    }
+  }, [isEdit, benefitToEdit, open, reset])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit({ name, category, description })
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent
+        className="max-w-lg gap-0 p-0 sm:max-w-lg"
+        showCloseButton={false}
+      >
+        <form className="flex max-h-[90vh] flex-col" onSubmit={handleSubmit}>
+          <div className="overflow-y-auto px-8 py-6">
+            <DialogTitle className="text-center text-2xl font-bold tracking-[-0.03em] uppercase">
+              {isEdit ? 'Editar benefício' : 'Novo benefício'}
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              {isEdit
+                ? 'Atualize os dados do benefício.'
+                : 'Preencha os campos abaixo para cadastrar um novo benefício no catálogo.'}
+            </DialogDescription>
+
+            <div className="mt-6 space-y-4">
+              <FormField label="Nome do benefício" required>
+                <Input
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Cesta Básica, Kit Gás, Auxílio Emergencial"
+                  required
+                  value={name}
+                />
+              </FormField>
+
+              <FormField label="Categoria" required>
+                <Select
+                  onValueChange={(v) => setCategory(v as BenefitCategory)}
+                  value={category}
+                >
+                  <SelectTrigger className="border-border w-full border">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CATEGORY_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormField>
+
+              <FormField label="Descrição" required>
+                <Textarea
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder="Descreva brevemente o benefício..."
+                  required
+                  rows={4}
+                  value={description}
+                />
+              </FormField>
+
+              <p className="text-destructive text-xs font-semibold tracking-wide uppercase">
+                Todos os campos com * são obrigatórios
+              </p>
+            </div>
+          </div>
+
+          <div className="border-border flex items-center justify-end gap-3 rounded-b-xl border-t bg-background px-8 py-4">
+            <Button
+              className="px-5"
+              onClick={() => onOpenChange(false)}
+              type="button"
+              variant="outline"
+            >
+              Cancelar
+            </Button>
+            <Button className="gap-2 px-5" type="submit" variant="default">
+              <Check className="size-4" />
+              {isEdit ? 'Salvar Alterações' : 'Concluir Cadastro'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface FormFieldProps {
+  label: string
+  required?: boolean
+  children: React.ReactNode
+}
+
+function FormField({ label, required, children }: FormFieldProps) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-sm font-medium">
+        {label}
+        {required && <span className="text-destructive ml-1">*</span>}
+      </Label>
+      {children}
+    </div>
+  )
+}

--- a/app/resources/js/components/usuarios/benefits-catalog-section.tsx
+++ b/app/resources/js/components/usuarios/benefits-catalog-section.tsx
@@ -1,0 +1,114 @@
+import { Package, Plus } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { toaster } from '@/components/toasters/toast-alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { BenefitCard } from './benefit-card'
+import { BenefitFormModal } from './benefit-form-modal'
+import { MOCK_BENEFITS } from './data'
+import type { Benefit, BenefitCategory } from './types'
+
+export function BenefitsCatalogSection() {
+  const [benefits, setBenefits] = useState<Benefit[]>(MOCK_BENEFITS)
+  const [isFormOpen, setIsFormOpen] = useState(false)
+  const [benefitToEdit, setBenefitToEdit] = useState<Benefit | null>(null)
+
+  const handleAdd = useCallback(() => {
+    setBenefitToEdit(null)
+    setIsFormOpen(true)
+  }, [])
+
+  const handleEdit = useCallback((benefit: Benefit) => {
+    setBenefitToEdit(benefit)
+    setIsFormOpen(true)
+  }, [])
+
+  const handleDelete = useCallback((benefit: Benefit) => {
+    if (typeof window !== 'undefined') {
+      const confirmed = window.confirm(
+        `Deseja realmente excluir o benefício "${benefit.name}"?`,
+      )
+      if (!confirmed) return
+    }
+    setBenefits((prev) => prev.filter((b) => b.id !== benefit.id))
+    toaster.createSuccess('Sucesso', `Benefício "${benefit.name}" excluído.`)
+  }, [])
+
+  const handleSubmit = useCallback(
+    (data: {
+      name: string
+      category: BenefitCategory
+      description: string
+    }) => {
+      if (benefitToEdit) {
+        setBenefits((prev) =>
+          prev.map((b) => (b.id === benefitToEdit.id ? { ...b, ...data } : b)),
+        )
+        toaster.createSuccess('Sucesso', 'Benefício atualizado.')
+      } else {
+        const newId =
+          benefits.length === 0 ? 1 : Math.max(...benefits.map((b) => b.id)) + 1
+        const newBenefit: Benefit = {
+          id: newId,
+          ...data,
+          created_at: new Date().toISOString(),
+        }
+        setBenefits((prev) => [newBenefit, ...prev])
+        toaster.createSuccess('Sucesso', 'Benefício cadastrado.')
+      }
+      setIsFormOpen(false)
+      setBenefitToEdit(null)
+    },
+    [benefitToEdit, benefits],
+  )
+
+  return (
+    <Card className="rounded-2xl border border-border shadow-sm">
+      <CardContent className="p-6">
+        <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <div className="bg-accent text-primary flex h-9 w-9 items-center justify-center rounded-lg">
+                <Package className="size-4" />
+              </div>
+              <h3 className="text-heading text-lg font-semibold">
+                Catálogo de Benefícios e Insumos
+              </h3>
+            </div>
+            <p className="text-foreground/70 max-w-2xl text-sm">
+              Crie, edite e organize a lista de auxílios (como cestas, kits e
+              complementos) ofertados pela organização.
+            </p>
+          </div>
+
+          <Button
+            className="gap-2 rounded-md bg-emerald-600 px-4 hover:bg-emerald-700"
+            onClick={handleAdd}
+          >
+            <Plus className="size-4" />
+            Novo Benefício
+          </Button>
+        </header>
+
+        <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {benefits.map((benefit) => (
+            <BenefitCard
+              key={benefit.id}
+              benefit={benefit}
+              onDelete={handleDelete}
+              onEdit={handleEdit}
+            />
+          ))}
+        </div>
+      </CardContent>
+
+      <BenefitFormModal
+        key={benefitToEdit ? `edit-${benefitToEdit.id}` : 'create'}
+        benefitToEdit={benefitToEdit}
+        onOpenChange={setIsFormOpen}
+        onSubmit={handleSubmit}
+        open={isFormOpen}
+      />
+    </Card>
+  )
+}

--- a/app/resources/js/components/usuarios/data.ts
+++ b/app/resources/js/components/usuarios/data.ts
@@ -1,0 +1,195 @@
+import {
+  Baby,
+  Backpack,
+  Droplets,
+  Flame,
+  HeartHandshake,
+  type LucideIcon,
+  ShoppingBasket,
+} from 'lucide-react'
+import type { Benefit, BenefitCategory, User } from './types'
+
+export const MOCK_USERS: User[] = [
+  {
+    id: 8932,
+    name: 'Ana Dias',
+    email: 'ana.dias@centelha.org',
+    role: 'Administrador',
+    status: 'Ativo',
+    last_access: '2026-06-24T09:41:00',
+    created_at: '2024-01-15T10:00:00',
+  },
+  {
+    id: 8945,
+    name: 'Carlos Mendes',
+    email: 'carlos.mendes@centelha.org',
+    role: 'Agente de Saúde',
+    status: 'Inativo',
+    last_access: '2026-06-23T16:20:00',
+    created_at: '2024-02-08T10:00:00',
+  },
+  {
+    id: 8971,
+    name: 'Patrícia Lima',
+    email: 'patricia.lima@centelha.org',
+    role: 'Coordenador',
+    status: 'Ativo',
+    last_access: '2026-06-24T08:15:00',
+    created_at: '2024-03-22T10:00:00',
+  },
+  {
+    id: 8988,
+    name: 'Rafael Souza',
+    email: 'rafael.souza@centelha.org',
+    role: 'Voluntário',
+    status: 'Ativo',
+    last_access: '2026-06-22T14:02:00',
+    created_at: '2024-05-10T10:00:00',
+  },
+  {
+    id: 9002,
+    name: 'Mariana Costa',
+    email: 'mariana.costa@centelha.org',
+    role: 'Agente de Saúde',
+    status: 'Pendente',
+    last_access: null,
+    created_at: '2026-06-20T10:00:00',
+  },
+  {
+    id: 9010,
+    name: 'Bruno Oliveira',
+    email: 'bruno.oliveira@centelha.org',
+    role: 'Voluntário',
+    status: 'Ativo',
+    last_access: '2026-06-19T11:48:00',
+    created_at: '2025-01-12T10:00:00',
+  },
+]
+
+export const MOCK_BENEFITS: Benefit[] = [
+  {
+    id: 1,
+    name: 'Cesta Básica',
+    category: 'Alimentação',
+    description:
+      'Fornecimento de mantimentos básicos de alimentação para garantir a segurança alimentar das famílias atendidas.',
+    created_at: '2024-01-10T10:00:00',
+  },
+  {
+    id: 2,
+    name: 'Kit Gás',
+    category: 'Gás',
+    description:
+      'Fornecimento ou subsídio de carga de botijão de gás doméstico (GLP) para preparo de refeições.',
+    created_at: '2024-01-10T10:00:00',
+  },
+  {
+    id: 3,
+    name: 'Kit Higiene',
+    category: 'Higiene',
+    description:
+      'Itens essenciais de asseio corporal, álcool e saneantes de ambiente.',
+    created_at: '2024-01-10T10:00:00',
+  },
+  {
+    id: 4,
+    name: 'Enxoval Bebê',
+    category: 'Vestuário',
+    description:
+      'Kit de roupas infantis básicas, fraldas e apoio inicial para mães e recém-nascidos.',
+    created_at: '2024-01-10T10:00:00',
+  },
+  {
+    id: 5,
+    name: 'Kit Escolar',
+    category: 'Educação',
+    description:
+      'Conjunto de cadernos, mochilas e materiais didáticos para estudantes da rede pública.',
+    created_at: '2024-01-10T10:00:00',
+  },
+  {
+    id: 6,
+    name: 'Auxílio Emergencial',
+    category: 'Emergência',
+    description:
+      'Apoio monetário extraordinário transitório ou recursos financeiros para situações críticas.',
+    created_at: '2024-01-10T10:00:00',
+  },
+]
+
+export const BENEFIT_CATEGORY_STYLES: Record<
+  BenefitCategory,
+  { label: string; className: string; icon: LucideIcon }
+> = {
+  Alimentação: {
+    label: 'Cesta Básica',
+    className: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+    icon: ShoppingBasket,
+  },
+  Gás: {
+    label: 'Kit Gás',
+    className: 'bg-orange-50 text-orange-700 border-orange-200',
+    icon: Flame,
+  },
+  Higiene: {
+    label: 'Kit Higiene',
+    className: 'bg-cyan-50 text-cyan-700 border-cyan-200',
+    icon: Droplets,
+  },
+  Vestuário: {
+    label: 'Enxoval Bebê',
+    className: 'bg-purple-50 text-purple-700 border-purple-200',
+    icon: Baby,
+  },
+  Educação: {
+    label: 'Kit Escolar',
+    className: 'bg-blue-50 text-blue-700 border-blue-200',
+    icon: Backpack,
+  },
+  Emergência: {
+    label: 'Auxílio Emergencial',
+    className: 'bg-red-50 text-red-700 border-red-200',
+    icon: HeartHandshake,
+  },
+}
+
+export function formatLastAccess(iso: string | null): string {
+  if (!iso) return '—'
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return '—'
+
+  const now = new Date()
+  const startOfToday = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  )
+  const startOfDate = new Date(
+    date.getFullYear(),
+    date.getMonth(),
+    date.getDate(),
+  )
+  const diffDays = Math.round(
+    (startOfToday.getTime() - startOfDate.getTime()) / 86_400_000,
+  )
+
+  const time = date.toLocaleTimeString('pt-BR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+
+  if (diffDays === 0) return `Hoje, ${time}`
+  if (diffDays === 1) return `Ontem, ${time}`
+  if (diffDays > 1 && diffDays < 7) {
+    return `${diffDays} dias atrás, ${time}`
+  }
+  return date.toLocaleDateString('pt-BR')
+}
+
+export function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 0 || !parts[0]) return '?'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  const last = parts[parts.length - 1] ?? parts[0]
+  return ((parts[0][0] ?? '') + (last[0] ?? '')).toUpperCase()
+}

--- a/app/resources/js/components/usuarios/delete-user-popover.tsx
+++ b/app/resources/js/components/usuarios/delete-user-popover.tsx
@@ -1,0 +1,66 @@
+import { Trash2 } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+
+interface DeleteUserPopoverProps {
+  userName: string
+  onDelete: () => void
+}
+
+export function DeleteUserPopover({
+  userName,
+  onDelete,
+}: DeleteUserPopoverProps) {
+  const [open, setOpen] = useState(false)
+
+  const handleConfirm = () => {
+    onDelete()
+    setOpen(false)
+  }
+
+  return (
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger
+        aria-label={`Excluir ${userName}`}
+        className="bg-red-50 text-red-600 hover:bg-red-100 flex size-8 items-center justify-center rounded-md transition-colors"
+      >
+        <Trash2 className="size-4" />
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-64" side="top" sideOffset={8}>
+        <PopoverHeader>
+          <PopoverTitle className="text-sm">Excluir usuário</PopoverTitle>
+          <PopoverDescription className="text-xs">
+            Tem certeza que deseja excluir <strong>{userName}</strong>? Esta
+            ação não pode ser desfeita.
+          </PopoverDescription>
+        </PopoverHeader>
+        <div className="mt-2 flex justify-end gap-2">
+          <Button
+            className="h-8 text-xs"
+            onClick={() => setOpen(false)}
+            size="sm"
+            variant="outline"
+          >
+            Cancelar
+          </Button>
+          <Button
+            className="h-8 text-xs"
+            onClick={handleConfirm}
+            size="sm"
+            variant="destructive"
+          >
+            Excluir
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/app/resources/js/components/usuarios/role-badge.tsx
+++ b/app/resources/js/components/usuarios/role-badge.tsx
@@ -1,0 +1,25 @@
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import type { UserRole } from './types'
+
+const ROLE_STYLES: Record<UserRole, string> = {
+  Administrador: 'bg-blue-50 text-blue-700 border-blue-200',
+  Coordenador: 'bg-violet-50 text-violet-700 border-violet-200',
+  'Agente de Saúde': 'bg-gray-100 text-gray-700 border-gray-200',
+  Voluntário: 'bg-amber-50 text-amber-700 border-amber-200',
+}
+
+interface RoleBadgeProps {
+  role: UserRole
+}
+
+export function RoleBadge({ role }: RoleBadgeProps) {
+  return (
+    <Badge
+      className={cn('px-3 py-1 font-semibold', ROLE_STYLES[role])}
+      variant="outline"
+    >
+      {role}
+    </Badge>
+  )
+}

--- a/app/resources/js/components/usuarios/status-badge.tsx
+++ b/app/resources/js/components/usuarios/status-badge.tsx
@@ -1,0 +1,24 @@
+import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
+import type { UserStatus } from './types'
+
+const STATUS_STYLES: Record<UserStatus, string> = {
+  Ativo: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+  Inativo: 'bg-red-50 text-red-700 border-red-200',
+  Pendente: 'bg-amber-50 text-amber-700 border-amber-200',
+}
+
+interface StatusBadgeProps {
+  status: UserStatus
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  return (
+    <Badge
+      className={cn('px-3 py-1 font-semibold', STATUS_STYLES[status])}
+      variant="outline"
+    >
+      {status}
+    </Badge>
+  )
+}

--- a/app/resources/js/components/usuarios/types.ts
+++ b/app/resources/js/components/usuarios/types.ts
@@ -1,0 +1,64 @@
+export type UserRole =
+  | 'Administrador'
+  | 'Agente de Saúde'
+  | 'Voluntário'
+  | 'Coordenador'
+
+export type UserStatus = 'Ativo' | 'Inativo' | 'Pendente'
+
+export interface User {
+  id: number
+  name: string
+  email: string
+  role: UserRole
+  status: UserStatus
+  last_access: string | null
+  created_at: string
+}
+
+export type BenefitCategory =
+  | 'Alimentação'
+  | 'Gás'
+  | 'Higiene'
+  | 'Vestuário'
+  | 'Educação'
+  | 'Emergência'
+
+export interface Benefit {
+  id: number
+  name: string
+  category: BenefitCategory
+  description: string
+  created_at: string
+}
+
+export interface PaginatedUsers {
+  data: User[]
+  current_page: number
+  last_page: number
+  from: number | null
+  to: number | null
+  total: number
+  per_page: number
+}
+
+export const ROLE_OPTIONS: { value: UserRole | 'all'; label: string }[] = [
+  { value: 'all', label: 'Todos os perfis' },
+  { value: 'Administrador', label: 'Administrador' },
+  { value: 'Coordenador', label: 'Coordenador' },
+  { value: 'Agente de Saúde', label: 'Agente de Saúde' },
+  { value: 'Voluntário', label: 'Voluntário' },
+]
+
+export const ROLE_OPTIONS_FORM: { value: UserRole; label: string }[] = [
+  { value: 'Administrador', label: 'Administrador' },
+  { value: 'Coordenador', label: 'Coordenador' },
+  { value: 'Agente de Saúde', label: 'Agente de Saúde' },
+  { value: 'Voluntário', label: 'Voluntário' },
+]
+
+export const STATUS_OPTIONS_FORM: { value: UserStatus; label: string }[] = [
+  { value: 'Ativo', label: 'Ativo' },
+  { value: 'Inativo', label: 'Inativo' },
+  { value: 'Pendente', label: 'Pendente' },
+]

--- a/app/resources/js/components/usuarios/user-form-modal.tsx
+++ b/app/resources/js/components/usuarios/user-form-modal.tsx
@@ -1,0 +1,192 @@
+import { Check } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  ROLE_OPTIONS_FORM,
+  STATUS_OPTIONS_FORM,
+  type User,
+  type UserRole,
+  type UserStatus,
+} from './types'
+
+interface UserFormModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userToEdit?: User | null
+  onSubmit: (data: {
+    name: string
+    email: string
+    role: UserRole
+    status: UserStatus
+  }) => void
+}
+
+export function UserFormModal({
+  open,
+  onOpenChange,
+  userToEdit,
+  onSubmit,
+}: UserFormModalProps) {
+  const isEdit = !!userToEdit
+
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [role, setRole] = useState<UserRole>('Voluntário')
+  const [status, setStatus] = useState<UserStatus>('Ativo')
+
+  const reset = useCallback(() => {
+    setName('')
+    setEmail('')
+    setRole('Voluntário')
+    setStatus('Ativo')
+  }, [])
+
+  useEffect(() => {
+    if (isEdit && userToEdit) {
+      setName(userToEdit.name)
+      setEmail(userToEdit.email)
+      setRole(userToEdit.role)
+      setStatus(userToEdit.status)
+    } else if (open) {
+      reset()
+    }
+  }, [isEdit, userToEdit, open, reset])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    onSubmit({ name, email, role, status })
+  }
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent
+        className="max-w-lg gap-0 p-0 sm:max-w-lg"
+        showCloseButton={false}
+      >
+        <form className="flex max-h-[90vh] flex-col" onSubmit={handleSubmit}>
+          <div className="overflow-y-auto px-8 py-6">
+            <DialogTitle className="text-center text-2xl font-bold tracking-[-0.03em] uppercase">
+              {isEdit ? 'Editar usuário' : 'Novo usuário'}
+            </DialogTitle>
+            <DialogDescription className="sr-only">
+              {isEdit
+                ? 'Atualize os dados do usuário.'
+                : 'Preencha os campos abaixo para cadastrar um novo usuário.'}
+            </DialogDescription>
+
+            <div className="mt-6 space-y-4">
+              <FormField label="Nome completo" required>
+                <Input
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Nome do usuário"
+                  required
+                  value={name}
+                />
+              </FormField>
+
+              <FormField label="E-mail" required>
+                <Input
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="usuario@centelha.org"
+                  required
+                  type="email"
+                  value={email}
+                />
+              </FormField>
+
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <FormField label="Perfil" required>
+                  <Select
+                    onValueChange={(v) => setRole(v as UserRole)}
+                    value={role}
+                  >
+                    <SelectTrigger className="border-border w-full border">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {ROLE_OPTIONS_FORM.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormField>
+
+                <FormField label="Status" required>
+                  <Select
+                    onValueChange={(v) => setStatus(v as UserStatus)}
+                    value={status}
+                  >
+                    <SelectTrigger className="border-border w-full border">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STATUS_OPTIONS_FORM.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormField>
+              </div>
+
+              <p className="text-destructive text-xs font-semibold tracking-wide uppercase">
+                Todos os campos com * são obrigatórios
+              </p>
+            </div>
+          </div>
+
+          <div className="border-border flex items-center justify-end gap-3 rounded-b-xl border-t bg-background px-8 py-4">
+            <Button
+              className="px-5"
+              onClick={() => onOpenChange(false)}
+              type="button"
+              variant="outline"
+            >
+              Cancelar
+            </Button>
+            <Button className="gap-2 px-5" type="submit" variant="default">
+              <Check className="size-4" />
+              {isEdit ? 'Salvar Alterações' : 'Concluir Cadastro'}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface FormFieldProps {
+  label: string
+  required?: boolean
+  children: React.ReactNode
+}
+
+function FormField({ label, required, children }: FormFieldProps) {
+  return (
+    <div className="space-y-1.5">
+      <Label className="text-sm font-medium">
+        {label}
+        {required && <span className="text-destructive ml-1">*</span>}
+      </Label>
+      {children}
+    </div>
+  )
+}

--- a/app/resources/js/components/usuarios/users-filter-bar.tsx
+++ b/app/resources/js/components/usuarios/users-filter-bar.tsx
@@ -1,0 +1,55 @@
+import { Search } from 'lucide-react'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { ROLE_OPTIONS } from './types'
+
+interface UsersFilterBarProps {
+  search: string
+  role: string
+  onSearchChange: (value: string) => void
+  onRoleChange: (value: string) => void
+  searchPlaceholder?: string
+}
+
+export function UsersFilterBar({
+  search,
+  role,
+  onSearchChange,
+  onRoleChange,
+  searchPlaceholder,
+}: UsersFilterBarProps) {
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-end">
+      <div className="relative w-full md:w-80">
+        <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+        <Input
+          className="pl-9"
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={searchPlaceholder ?? 'Buscar por nomes ou e-mail...'}
+          value={search}
+        />
+      </div>
+
+      <div className="w-full md:w-56">
+        <Select onValueChange={onRoleChange} value={role}>
+          <SelectTrigger className="border-border w-full border">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {ROLE_OPTIONS.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  )
+}

--- a/app/resources/js/components/usuarios/users-pagination.tsx
+++ b/app/resources/js/components/usuarios/users-pagination.tsx
@@ -1,0 +1,89 @@
+import { ChevronLeft, ChevronRight, MoreHorizontal } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface UsersPaginationProps {
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+}
+
+type PageItem =
+  | { key: string; type: 'ellipsis' }
+  | { key: string; type: 'page'; value: number }
+
+function getPageNumbers(current: number, total: number): PageItem[] {
+  if (total <= 5) {
+    return Array.from({ length: total }, (_, i) => ({
+      key: String(i + 1),
+      type: 'page' as const,
+      value: i + 1,
+    }))
+  }
+  const pages: PageItem[] = [{ key: '1', type: 'page', value: 1 }]
+  if (current > 3) pages.push({ key: 'ellipsis-start', type: 'ellipsis' })
+  const start = Math.max(2, current - 1)
+  const end = Math.min(total - 1, current + 1)
+  for (let i = start; i <= end; i++) {
+    pages.push({ key: String(i), type: 'page', value: i })
+  }
+  if (current < total - 2) pages.push({ key: 'ellipsis-end', type: 'ellipsis' })
+  pages.push({ key: String(total), type: 'page', value: total })
+  return pages
+}
+
+export function UsersPagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+}: UsersPaginationProps) {
+  if (totalPages <= 1) return null
+  const pages = getPageNumbers(currentPage, totalPages)
+  return (
+    <nav aria-label="Paginação" className="flex items-center gap-1">
+      <button
+        aria-label="Página anterior"
+        className="border-border text-foreground/70 hover:bg-muted flex size-8 items-center justify-center rounded-md border transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+        disabled={currentPage <= 1}
+        onClick={() => onPageChange(currentPage - 1)}
+        type="button"
+      >
+        <ChevronLeft className="size-4" />
+      </button>
+      {pages.map((item) =>
+        item.type === 'ellipsis' ? (
+          <span
+            key={item.key}
+            className="text-foreground/50 flex size-8 items-center justify-center"
+          >
+            <MoreHorizontal className="size-4" />
+          </span>
+        ) : (
+          <button
+            key={item.key}
+            aria-current={item.value === currentPage ? 'page' : undefined}
+            aria-label={`Página ${item.value}`}
+            className={cn(
+              'flex size-8 items-center justify-center rounded-md text-sm font-medium transition-colors',
+              item.value === currentPage
+                ? 'bg-primary text-white'
+                : 'border-border text-foreground/70 hover:bg-muted border',
+            )}
+            onClick={() => onPageChange(item.value)}
+            type="button"
+          >
+            {item.value}
+          </button>
+        ),
+      )}
+      <button
+        aria-label="Próxima página"
+        className="border-border text-foreground/70 hover:bg-muted flex size-8 items-center justify-center rounded-md border transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+        disabled={currentPage >= totalPages}
+        onClick={() => onPageChange(currentPage + 1)}
+        type="button"
+      >
+        <ChevronRight className="size-4" />
+      </button>
+    </nav>
+  )
+}

--- a/app/resources/js/components/usuarios/users-section.tsx
+++ b/app/resources/js/components/usuarios/users-section.tsx
@@ -1,0 +1,166 @@
+import { Plus, Users } from 'lucide-react'
+import { useCallback, useMemo, useState } from 'react'
+import { toaster } from '@/components/toasters/toast-alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { MOCK_USERS } from './data'
+import type { User, UserRole, UserStatus } from './types'
+import { UserFormModal } from './user-form-modal'
+import { UsersFilterBar } from './users-filter-bar'
+import { UsersTable } from './users-table'
+import { ViewUserModal } from './view-user-modal'
+
+const PER_PAGE = 5
+
+export function UsersSection() {
+  const [users, setUsers] = useState<User[]>(MOCK_USERS)
+  const [search, setSearch] = useState('')
+  const [role, setRole] = useState<string>('all')
+  const [currentPage, setCurrentPage] = useState(1)
+
+  const [isFormOpen, setIsFormOpen] = useState(false)
+  const [userToEdit, setUserToEdit] = useState<User | null>(null)
+  const [isViewOpen, setIsViewOpen] = useState(false)
+  const [userToView, setUserToView] = useState<User | null>(null)
+
+  const filtered = useMemo(() => {
+    const term = search.trim().toLowerCase()
+    return users.filter((u) => {
+      const matchesSearch =
+        term === '' ||
+        u.name.toLowerCase().includes(term) ||
+        u.email.toLowerCase().includes(term)
+      const matchesRole = role === 'all' || u.role === role
+      return matchesSearch && matchesRole
+    })
+  }, [users, search, role])
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PER_PAGE))
+  const safePage = Math.min(currentPage, totalPages)
+  const start = (safePage - 1) * PER_PAGE
+  const end = start + PER_PAGE
+  const pageData = filtered.slice(start, end)
+
+  const handleAdd = useCallback(() => {
+    setUserToEdit(null)
+    setIsFormOpen(true)
+  }, [])
+
+  const handleEdit = useCallback((user: User) => {
+    setUserToEdit(user)
+    setIsFormOpen(true)
+  }, [])
+
+  const handleView = useCallback((user: User) => {
+    setUserToView(user)
+    setIsViewOpen(true)
+  }, [])
+
+  const handleDelete = useCallback((user: User) => {
+    setUsers((prev) => prev.filter((u) => u.id !== user.id))
+    toaster.createSuccess('Sucesso', `Usuário ${user.name} excluído.`)
+  }, [])
+
+  const handleSubmit = useCallback(
+    (data: {
+      name: string
+      email: string
+      role: UserRole
+      status: UserStatus
+    }) => {
+      if (userToEdit) {
+        setUsers((prev) =>
+          prev.map((u) => (u.id === userToEdit.id ? { ...u, ...data } : u)),
+        )
+        toaster.createSuccess('Sucesso', 'Usuário atualizado.')
+      } else {
+        const newId = Math.max(...users.map((u) => u.id)) + 1
+        const newUser: User = {
+          id: newId,
+          ...data,
+          last_access: null,
+          created_at: new Date().toISOString(),
+        }
+        setUsers((prev) => [newUser, ...prev])
+        toaster.createSuccess('Sucesso', 'Usuário cadastrado.')
+      }
+      setIsFormOpen(false)
+      setUserToEdit(null)
+    },
+    [userToEdit, users],
+  )
+
+  const handleSearchChange = useCallback((value: string) => {
+    setSearch(value)
+    setCurrentPage(1)
+  }, [])
+
+  const handleRoleChange = useCallback((value: string) => {
+    setRole(value)
+    setCurrentPage(1)
+  }, [])
+
+  return (
+    <Card className="rounded-2xl border border-border shadow-sm">
+      <CardContent className="p-6">
+        <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-2">
+            <div className="bg-accent text-primary flex h-9 w-9 items-center justify-center rounded-lg">
+              <Users className="size-4" />
+            </div>
+            <h3 className="text-heading text-lg font-semibold">
+              Usuários Cadastrados
+            </h3>
+          </div>
+
+          <UsersFilterBar
+            onRoleChange={handleRoleChange}
+            onSearchChange={handleSearchChange}
+            role={role}
+            search={search}
+          />
+        </header>
+
+        <div className="mt-4">
+          <UsersTable
+            currentPage={safePage}
+            endIndex={Math.min(end, filtered.length)}
+            onDelete={handleDelete}
+            onEdit={handleEdit}
+            onPageChange={setCurrentPage}
+            onView={handleView}
+            startIndex={filtered.length === 0 ? 0 : start + 1}
+            total={filtered.length}
+            totalPages={totalPages}
+            users={pageData}
+          />
+        </div>
+
+        <div className="mt-4 flex justify-end">
+          <Button
+            className="gap-2 rounded-md px-4"
+            onClick={handleAdd}
+            variant="default"
+          >
+            <Plus className="size-4" />
+            Novo usuário
+          </Button>
+        </div>
+      </CardContent>
+
+      <UserFormModal
+        key={userToEdit ? `edit-${userToEdit.id}` : 'create'}
+        onOpenChange={setIsFormOpen}
+        onSubmit={handleSubmit}
+        open={isFormOpen}
+        userToEdit={userToEdit}
+      />
+
+      <ViewUserModal
+        onOpenChange={setIsViewOpen}
+        open={isViewOpen}
+        user={userToView}
+      />
+    </Card>
+  )
+}

--- a/app/resources/js/components/usuarios/users-table-row.tsx
+++ b/app/resources/js/components/usuarios/users-table-row.tsx
@@ -1,0 +1,79 @@
+import { Eye, Pencil, Trash2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { formatLastAccess, getInitials } from './data'
+import { RoleBadge } from './role-badge'
+import { StatusBadge } from './status-badge'
+import type { User } from './types'
+
+interface UsersTableRowProps {
+  user: User
+  onView: (user: User) => void
+  onEdit: (user: User) => void
+  onDelete: (user: User) => void
+}
+
+export function UsersTableRow({
+  user,
+  onView,
+  onEdit,
+  onDelete,
+}: UsersTableRowProps) {
+  return (
+    <tr className="border-border hover:bg-muted/30 border-t transition-colors">
+      <td className="px-6 py-4 text-sm">
+        <div className="flex items-center gap-3">
+          <div
+            className={cn(
+              'flex h-10 w-10 items-center justify-center rounded-full',
+              'bg-blue-100 text-blue-700 font-semibold text-sm',
+            )}
+          >
+            {getInitials(user.name)}
+          </div>
+          <div className="flex flex-col">
+            <span className="text-foreground font-semibold">{user.name}</span>
+            <span className="text-foreground/60 text-xs">ID: {user.id}</span>
+          </div>
+        </div>
+      </td>
+      <td className="text-foreground/80 px-6 py-4 text-sm">{user.email}</td>
+      <td className="px-6 py-4 text-sm">
+        <RoleBadge role={user.role} />
+      </td>
+      <td className="px-6 py-4 text-sm">
+        <StatusBadge status={user.status} />
+      </td>
+      <td className="text-foreground/80 px-6 py-4 text-sm">
+        {formatLastAccess(user.last_access)}
+      </td>
+      <td className="px-6 py-4 text-sm">
+        <div className="flex items-center gap-2">
+          <button
+            aria-label={`Visualizar ${user.name}`}
+            className="bg-blue-50 text-blue-600 hover:bg-blue-100 flex size-8 items-center justify-center rounded-md transition-colors"
+            onClick={() => onView(user)}
+            type="button"
+          >
+            <Eye className="size-4" />
+          </button>
+          <button
+            aria-label={`Editar ${user.name}`}
+            className="bg-orange-50 text-orange-600 hover:bg-orange-100 flex size-8 items-center justify-center rounded-md transition-colors"
+            onClick={() => onEdit(user)}
+            type="button"
+          >
+            <Pencil className="size-4" />
+          </button>
+          <button
+            aria-label={`Excluir ${user.name}`}
+            className="bg-red-50 text-red-600 hover:bg-red-100 flex size-8 items-center justify-center rounded-md transition-colors"
+            onClick={() => onDelete(user)}
+            type="button"
+          >
+            <Trash2 className="size-4" />
+          </button>
+        </div>
+      </td>
+    </tr>
+  )
+}

--- a/app/resources/js/components/usuarios/users-table.tsx
+++ b/app/resources/js/components/usuarios/users-table.tsx
@@ -1,0 +1,86 @@
+import { Card, CardContent } from '@/components/ui/card'
+import type { User } from './types'
+import { UsersPagination } from './users-pagination'
+import { UsersTableRow } from './users-table-row'
+
+interface UsersTableProps {
+  users: User[]
+  startIndex: number
+  endIndex: number
+  total: number
+  currentPage: number
+  totalPages: number
+  onPageChange: (page: number) => void
+  onView: (user: User) => void
+  onEdit: (user: User) => void
+  onDelete: (user: User) => void
+}
+
+export function UsersTable({
+  users,
+  startIndex,
+  endIndex,
+  total,
+  currentPage,
+  totalPages,
+  onPageChange,
+  onView,
+  onEdit,
+  onDelete,
+}: UsersTableProps) {
+  return (
+    <Card className="rounded-2xl">
+      <CardContent className="p-0">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[720px] table-auto">
+            <thead>
+              <tr className="bg-muted/40 text-foreground/70 text-left text-xs font-semibold tracking-wide uppercase">
+                <th className="px-6 py-3">Usuário</th>
+                <th className="px-6 py-3">E-mail</th>
+                <th className="px-6 py-3">Perfil</th>
+                <th className="px-6 py-3">Status</th>
+                <th className="px-6 py-3">Último acesso</th>
+                <th className="px-6 py-3">Ações</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.length === 0 ? (
+                <tr>
+                  <td
+                    className="text-foreground/60 px-6 py-12 text-center text-sm"
+                    colSpan={6}
+                  >
+                    Nenhum usuário encontrado.
+                  </td>
+                </tr>
+              ) : (
+                users.map((user) => (
+                  <UsersTableRow
+                    key={user.id}
+                    onDelete={onDelete}
+                    onEdit={onEdit}
+                    onView={onView}
+                    user={user}
+                  />
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {users.length > 0 && (
+          <div className="border-border flex items-center justify-between border-t p-4">
+            <p className="text-foreground/70 text-sm">
+              Mostrando {startIndex} a {endIndex} de {total} usuários
+            </p>
+            <UsersPagination
+              currentPage={currentPage}
+              onPageChange={onPageChange}
+              totalPages={totalPages}
+            />
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/resources/js/components/usuarios/view-user-modal.tsx
+++ b/app/resources/js/components/usuarios/view-user-modal.tsx
@@ -1,0 +1,92 @@
+import { Mail, ShieldCheck, User as UserIcon } from 'lucide-react'
+import { Card, CardContent } from '@/components/ui/card'
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { cn } from '@/lib/utils'
+import { formatLastAccess, getInitials } from './data'
+import { RoleBadge } from './role-badge'
+import { StatusBadge } from './status-badge'
+import type { User } from './types'
+
+interface ViewUserModalProps {
+  user: User | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function ViewUserModal({
+  user,
+  open,
+  onOpenChange,
+}: ViewUserModalProps) {
+  if (!user) return null
+
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-lg gap-0 p-0 sm:max-w-lg">
+        <div className="px-8 py-6">
+          <DialogTitle className="text-center text-2xl font-bold tracking-[-0.03em] uppercase">
+            Detalhes do Usuário
+          </DialogTitle>
+
+          <div className="mt-6 space-y-4">
+            <div className="flex items-center gap-4">
+              <div
+                className={cn(
+                  'flex h-14 w-14 items-center justify-center rounded-full text-base font-semibold',
+                  'bg-blue-100 text-blue-700',
+                )}
+              >
+                {getInitials(user.name)}
+              </div>
+              <div>
+                <p className="text-lg font-semibold">{user.name}</p>
+                <p className="text-foreground/60 text-xs">ID: {user.id}</p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2 flex-wrap">
+              <RoleBadge role={user.role} />
+              <StatusBadge status={user.status} />
+            </div>
+
+            <Card className="rounded-xl">
+              <CardContent className="space-y-3 p-4">
+                <div className="flex items-center gap-3">
+                  <div className="bg-accent text-primary flex size-8 items-center justify-center rounded-lg">
+                    <Mail className="size-4" />
+                  </div>
+                  <div>
+                    <p className="text-foreground/60 text-xs">E-mail</p>
+                    <p className="text-sm font-semibold">{user.email}</p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <div className="bg-accent text-primary flex size-8 items-center justify-center rounded-lg">
+                    <ShieldCheck className="size-4" />
+                  </div>
+                  <div>
+                    <p className="text-foreground/60 text-xs">Perfil</p>
+                    <p className="text-sm font-semibold">{user.role}</p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <div className="bg-accent text-primary flex size-8 items-center justify-center rounded-lg">
+                    <UserIcon className="size-4" />
+                  </div>
+                  <div>
+                    <p className="text-foreground/60 text-xs">Último acesso</p>
+                    <p className="text-sm font-semibold">
+                      {formatLastAccess(user.last_access)}
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/app/resources/js/pages/admin/gestao-sistema/configuracoes-gerais.tsx
+++ b/app/resources/js/pages/admin/gestao-sistema/configuracoes-gerais.tsx
@@ -42,6 +42,7 @@ export default function ConfiguracoesGerais() {
         schema={configsGeraisSchema}
       >
         <FormContent
+          communityCenter={communityCenter}
           faviconFile={faviconFile}
           logoFile={logoFile}
           onFaviconChange={(files) =>
@@ -60,11 +61,13 @@ export default function ConfiguracoesGerais() {
 
 // Componente interno
 function FormContent({
+  communityCenter,
   logoFile,
   faviconFile,
   onLogoChange,
   onFaviconChange,
 }: {
+  communityCenter: SharedData['communityCenter']
   logoFile: File | null
   faviconFile: File | null
   onLogoChange: (files: FileWithPreview[]) => void
@@ -91,6 +94,8 @@ function FormContent({
   return (
     <>
       <ConfigsGeraisForm
+        currentFaviconUrl={communityCenter?.favicon_url}
+        currentLogoUrl={communityCenter?.logo_url}
         onFaviconChange={onFaviconChange}
         onLogoChange={onLogoChange}
       />

--- a/app/resources/js/pages/admin/gestao-sistema/usuarios-beneficios.tsx
+++ b/app/resources/js/pages/admin/gestao-sistema/usuarios-beneficios.tsx
@@ -1,0 +1,20 @@
+import { Head } from '@inertiajs/react'
+import { BenefitsCatalogSection } from '@/components/usuarios/benefits-catalog-section'
+import { UsersSection } from '@/components/usuarios/users-section'
+import { LayoutBase } from '@/layouts/layout'
+
+export default function UsuariosBeneficios() {
+  return (
+    <LayoutBase
+      description="Gerencie os acessos do sistema, perfis administrativos e cadastre os benefícios sociais e insumos distribuídos às famílias."
+      tagTitle="Gestão Global do Sistema"
+      titlePage="Usuários e Benefícios"
+    >
+      <Head title="Usuários e Benefícios" />
+      <div className="space-y-6">
+        <UsersSection />
+        <BenefitsCatalogSection />
+      </div>
+    </LayoutBase>
+  )
+}

--- a/app/resources/js/pages/auth/login.tsx
+++ b/app/resources/js/pages/auth/login.tsx
@@ -56,7 +56,7 @@ export default function Login({
               <img
                 alt={communityCenter?.name ?? 'Centelha'}
                 className="h-20 w-auto"
-                src="/logo.svg"
+                src={communityCenter?.logo_url ?? '/logo.svg'}
               />
               <div className="space-y-2">
                 <h1 className="text-[22px] font-semibold text-slate-700">

--- a/app/resources/js/pages/home.tsx
+++ b/app/resources/js/pages/home.tsx
@@ -70,6 +70,20 @@ export default function Home({ previewSettings }: { previewSettings?: Record<str
   const texts = (pageSettings?.texts as Record<string, string>) ?? {};
   const t = (key: string, fallback: string) => texts[key] ?? fallback;
 
+  const inicioRef = useRef<HTMLElement>(null);
+  const beneficiosRef = useRef<HTMLElement>(null);
+  const comoFuncionaRef = useRef<HTMLElement>(null);
+
+  const scrollTo = (ref: React.RefObject<HTMLElement | null>) => {
+    ref.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const navItems = [
+    { name: t('nav_inicio', 'Início'), ref: inicioRef },
+    { name: t('nav_beneficios', 'Benefícios'), ref: beneficiosRef },
+    { name: t('nav_como_funciona', 'Como funciona'), ref: comoFuncionaRef },
+  ];
+
   const steps = [
     { step: '1', title: t('step_1_title', 'Cadastre sua comunidade em minutos.') },
     { step: '2', title: t('step_2_title', 'Organize seus fluxos e doacoes.') },

--- a/app/resources/js/types/index.ts
+++ b/app/resources/js/types/index.ts
@@ -24,6 +24,8 @@ export interface CommunityCenter {
 	rodape_text: string;
 	logo_path: string | null;
 	favicon_path: string | null;
+	logo_url: string;
+	favicon_url: string;
 	fontFamily: string;
 	settings: Record<string, unknown>;
 	colors: Record<string, string>;

--- a/app/resources/views/app.blade.php
+++ b/app/resources/views/app.blade.php
@@ -8,7 +8,7 @@
 
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />
-        <link rel="icon" type="image/png" href="{{ asset('logo.png') }}" />
+        <link rel="icon" type="image/png" href="{{ $communityCenter?->favicon_url ?? asset('logo.png') }}" />
 
         @routes
         @viteReactRefresh

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -34,6 +34,10 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::get('gestao-sistema/customizacao-tela', [PageCustomizationController::class, 'index'])->name('gestao-sistema.customizacao-tela');
     Route::get('gestao-sistema/customizacao-tela/{pageKey}', [PageCustomizationController::class, 'show'])->name('gestao-sistema.customizacao-tela.edit');
     Route::put('gestao-sistema/customizacao-tela/{pageKey}', [PageCustomizationController::class, 'update'])->name('gestao-sistema.customizacao-tela.update');
+
+    Route::get('gestao-sistema/usuarios-beneficios', function () {
+        return Inertia::render('admin/gestao-sistema/usuarios-beneficios');
+    })->name('gestao-sistema.usuarios-beneficios');
 });
 
 Route::middleware(['auth'])->group(function () {

--- a/app/tests/Feature/ConfiguracoesGeraisTest.php
+++ b/app/tests/Feature/ConfiguracoesGeraisTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\CommunityCenter;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ConfiguracoesGeraisTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function createCommunityCenter(array $overrides = []): CommunityCenter
+    {
+        return CommunityCenter::firstOrCreate(
+            ['name' => 'Centelha'],
+            array_merge([
+                'location' => '',
+                'slogan' => 'Slogan',
+                'rodape_text' => '',
+                'logo_path' => './logo.png',
+                'favicon_path' => './logo.png',
+                'fontFamily' => 'Inter',
+                'settings' => [],
+            ], $overrides)
+        );
+    }
+
+    public function test_admin_can_upload_logo(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create(['role' => 'admin']);
+        $this->createCommunityCenter();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put('/gestao-sistema/configuracoes-gerais', [
+                '_token' => 'test-token',
+                'name' => 'Centelha',
+                'fontFamily' => 'Inter',
+                'logo' => UploadedFile::fake()->image('logo.png', 100, 100),
+            ]);
+
+        $center = CommunityCenter::first();
+
+        $this->assertNotNull($center->logo_path);
+        $this->assertStringStartsWith('logos/', $center->logo_path);
+        Storage::disk('public')->assertExists($center->logo_path);
+    }
+
+    public function test_uploading_new_logo_deletes_old_one(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create(['role' => 'admin']);
+        $center = $this->createCommunityCenter([
+            'logo_path' => 'logos/old-hash.png',
+        ]);
+        Storage::disk('public')->put('logos/old-hash.png', 'old-content');
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put('/gestao-sistema/configuracoes-gerais', [
+                '_token' => 'test-token',
+                'name' => $center->name,
+                'fontFamily' => $center->fontFamily,
+                'logo' => UploadedFile::fake()->image('new-logo.png', 100, 100),
+            ]);
+
+        $center->refresh();
+
+        Storage::disk('public')->assertMissing('logos/old-hash.png');
+        Storage::disk('public')->assertExists($center->logo_path);
+    }
+
+    public function test_remove_logo_flag_deletes_file_and_clears_path(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create(['role' => 'admin']);
+        $center = $this->createCommunityCenter([
+            'logo_path' => 'logos/logo-hash.png',
+        ]);
+        Storage::disk('public')->put('logos/logo-hash.png', 'content');
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put('/gestao-sistema/configuracoes-gerais', [
+                '_token' => 'test-token',
+                'name' => $center->name,
+                'fontFamily' => $center->fontFamily,
+                'remove_logo' => '1',
+            ]);
+
+        $center->refresh();
+
+        $this->assertNull($center->logo_path);
+        Storage::disk('public')->assertMissing('logos/logo-hash.png');
+    }
+
+    public function test_admin_can_upload_favicon(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create(['role' => 'admin']);
+        $this->createCommunityCenter();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put('/gestao-sistema/configuracoes-gerais', [
+                '_token' => 'test-token',
+                'name' => 'Centelha',
+                'fontFamily' => 'Inter',
+                'favicon' => UploadedFile::fake()->image('favicon.png', 32, 32),
+            ]);
+
+        $center = CommunityCenter::first();
+
+        $this->assertNotNull($center->favicon_path);
+        $this->assertStringStartsWith('favicons/', $center->favicon_path);
+        Storage::disk('public')->assertExists($center->favicon_path);
+    }
+
+    public function test_remove_favicon_flag_deletes_file_and_clears_path(): void
+    {
+        Storage::fake('public');
+
+        $user = User::factory()->create(['role' => 'admin']);
+        $center = $this->createCommunityCenter([
+            'favicon_path' => 'favicons/favicon-hash.png',
+        ]);
+        Storage::disk('public')->put('favicons/favicon-hash.png', 'content');
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put('/gestao-sistema/configuracoes-gerais', [
+                '_token' => 'test-token',
+                'name' => $center->name,
+                'fontFamily' => $center->fontFamily,
+                'remove_favicon' => '1',
+            ]);
+
+        $center->refresh();
+
+        $this->assertNull($center->favicon_path);
+        Storage::disk('public')->assertMissing('favicons/favicon-hash.png');
+    }
+
+    public function test_logo_url_accessor_returns_default_when_path_is_null(): void
+    {
+        $center = $this->createCommunityCenter(['logo_path' => null]);
+
+        $this->assertStringEndsWith('logo.svg', $center->logo_url);
+    }
+
+    public function test_logo_url_accessor_handles_legacy_static_path(): void
+    {
+        $center = $this->createCommunityCenter(['logo_path' => './logo.png']);
+
+        $this->assertStringEndsWith('logo.png', $center->logo_url);
+    }
+
+    public function test_logo_url_accessor_returns_storage_url_for_uploaded_file(): void
+    {
+        Storage::fake('public');
+
+        $center = $this->createCommunityCenter(['logo_path' => 'logos/hash.png']);
+
+        $this->assertStringContainsString('/storage/logos/hash.png', $center->logo_url);
+    }
+
+    public function test_logo_file_path_returns_null_for_missing_file(): void
+    {
+        Storage::fake('public');
+
+        $center = $this->createCommunityCenter(['logo_path' => 'logos/missing.png']);
+
+        $this->assertNull($center->logoFilePath());
+    }
+
+    public function test_logo_file_path_returns_real_path_for_existing_file(): void
+    {
+        Storage::fake('public');
+
+        $center = $this->createCommunityCenter(['logo_path' => 'logos/hash.png']);
+        Storage::disk('public')->put('logos/hash.png', 'content');
+
+        $this->assertNotNull($center->logoFilePath());
+    }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,6 +27,8 @@ services:
       RUN_MIGRATIONS: "1"
       RUN_SEEDERS: "1"
       APP_ENV: production
+      APP_URL: ${APP_PUBLIC_URL:-http://localhost}
+      AWS_URL: ${MINIO_PUBLIC_URL:-http://localhost:9000/centelha}
     volumes:
       - app_public:/var/www/html/public
     depends_on:
@@ -81,6 +83,8 @@ services:
     environment:
       MINIO_ROOT_USER: centelha
       MINIO_ROOT_PASSWORD: centelha-secret
+    ports:
+      - "9000:9000"
     volumes:
       - minio-data:/data
     healthcheck:


### PR DESCRIPTION
- Adiciona comando centelha:migrate-delivery-receipts para migrar comprovantes para MinIO
- Adiciona .env.example com variáveis APP_PUBLIC_URL e MINIO_PUBLIC_URL
- Refatora upload de logo/favicon para usar StorageService com replace e delete
- Adiciona accessors logo_url e favicon_url no modelo CommunityCenter
- Compartilha communityCenter na view para usar logo/favicon dinâmicos
- Adiciona storage:link no entrypoint do Docker
- Atualiza compose de produção com APP_URL e AWS_URL via variáveis de ambiente
- Adiciona testes para ConfiguracoesGerais com upload, remoção e accessors