### PR TITLE
refactor(php): reforçar base de tipos e segurança (strict_types, $fillable, return types)

### DIFF
--- a/app/app/Casts/MaskedCpf.php
+++ b/app/app/Casts/MaskedCpf.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Casts;
 
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;

--- a/app/app/Casts/MaskedCpf.php
+++ b/app/app/Casts/MaskedCpf.php
@@ -9,16 +9,23 @@ use Illuminate\Database\Eloquent\Model;
 
 class MaskedCpf implements CastsAttributes
 {
-    public function get($model, string $key, $value, array $attributes)
+    public function get(Model $model, string $key, mixed $value, array $attributes): ?string
     {
-        if (!$value) return null;
+        if (! $value) {
+            return null;
+        }
+
         $clean = preg_replace('/\D/', '', $value);
+
         return preg_replace('/(\d{3})(\d{3})(\d{3})(\d{2})/', '***.$2.$3-**', $clean);
     }
 
-    public function set($model, string $key, $value, array $attributes)
+    public function set(Model $model, string $key, mixed $value, array $attributes): ?string
     {
-        if (!$value) return null;
+        if (! $value) {
+            return null;
+        }
+
         return preg_replace('/\D/', '', $value);
     }
 }

--- a/app/app/Console/Commands/MigrateBenefitImages.php
+++ b/app/app/Console/Commands/MigrateBenefitImages.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Console\Commands;
 
 use App\Models\Benefit;

--- a/app/app/Console/Commands/MigrateDeliveryReceipts.php
+++ b/app/app/Console/Commands/MigrateDeliveryReceipts.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Console\Commands;
 
 use App\Models\Delivery;

--- a/app/app/Constants/Messages.php
+++ b/app/app/Constants/Messages.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Constants;
 
 class Messages

--- a/app/app/Enums/UserRole.php
+++ b/app/app/Enums/UserRole.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Enums;
 
 enum UserRole: string

--- a/app/app/Http/Controllers/Admin/AppearanceController.php
+++ b/app/app/Http/Controllers/Admin/AppearanceController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Admin/AppearanceController.php
+++ b/app/app/Http/Controllers/Admin/AppearanceController.php
@@ -6,34 +6,34 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\CommunityCenter;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Redirect;
 
 class AppearanceController extends Controller
 {
-    public function update(Request $request)
+    public function update(Request $request): RedirectResponse
     {
         $validated = $request->validate([
-            'primary'        => 'required|string',
-            'background'     => 'required|string',
-            'surface'        => 'required|string',
-            'text_primary'   => 'required|string',
+            'primary' => 'required|string',
+            'background' => 'required|string',
+            'surface' => 'required|string',
+            'text_primary' => 'required|string',
             'text_secondary' => 'required|string',
-            'text_disabled'  => 'required|string',
-            'hover'          => 'required|string',
-            'active'         => 'required|string',
-            'success'        => 'required|string',
-            'error'          => 'required|string',
-            'warning'        => 'required|string',
-            'info'           => 'required|string',
-            'button'         => 'required|string',
+            'text_disabled' => 'required|string',
+            'hover' => 'required|string',
+            'active' => 'required|string',
+            'success' => 'required|string',
+            'error' => 'required|string',
+            'warning' => 'required|string',
+            'info' => 'required|string',
+            'button' => 'required|string',
         ]);
 
         $center = CommunityCenter::firstOrCreate([]);
 
         $center->update([
-            'colors' => $validated
+            'colors' => $validated,
         ]);
 
         Cache::forget('community_center');

--- a/app/app/Http/Controllers/Admin/ConfiguracoesGeraisController.php
+++ b/app/app/Http/Controllers/Admin/ConfiguracoesGeraisController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Admin/ConfiguracoesGeraisController.php
+++ b/app/app/Http/Controllers/Admin/ConfiguracoesGeraisController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\CommunityCenter;
 use App\Services\StorageService;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 
@@ -14,7 +15,7 @@ class ConfiguracoesGeraisController extends Controller
 {
     public function __construct(private readonly StorageService $storage) {}
 
-    public function update(Request $request)
+    public function update(Request $request): RedirectResponse
     {
         $validated = $request->validate([
             'name' => 'required|string|max:255',

--- a/app/app/Http/Controllers/Admin/PageCustomizationController.php
+++ b/app/app/Http/Controllers/Admin/PageCustomizationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Admin/PageCustomizationController.php
+++ b/app/app/Http/Controllers/Admin/PageCustomizationController.php
@@ -6,13 +6,15 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\CommunityCenter;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class PageCustomizationController extends Controller
 {
-    public function index()
+    public function index(): Response
     {
         $availablePages = [
             [
@@ -49,7 +51,7 @@ class PageCustomizationController extends Controller
 
     private const ALLOWED_PAGES = ['dashboard', 'home', 'login', 'familia', 'beneficios'];
 
-    public function show(string $pageKey)
+    public function show(string $pageKey): Response
     {
         abort_if(! in_array($pageKey, self::ALLOWED_PAGES, true), 404, "Página '{$pageKey}' não encontrada.");
 
@@ -74,7 +76,7 @@ class PageCustomizationController extends Controller
         ]);
     }
 
-    public function update(Request $request, string $pageKey)
+    public function update(Request $request, string $pageKey): RedirectResponse
     {
         abort_if(! in_array($pageKey, self::ALLOWED_PAGES, true), 404, "Página '{$pageKey}' não encontrada.");
 

--- a/app/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/app/Http/Controllers/Auth/NewPasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/BenefitController.php
+++ b/app/app/Http/Controllers/BenefitController.php
@@ -8,8 +8,10 @@ use App\Http\Requests\StoreBenefitRequest;
 use App\Http\Requests\UpdateBenefitRequest;
 use App\Models\Benefit;
 use App\Services\StorageService;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class BenefitController extends Controller
 {
@@ -19,7 +21,7 @@ class BenefitController extends Controller
 
     public function __construct(private readonly StorageService $storage) {}
 
-    public function index(Request $request)
+    public function index(Request $request): Response
     {
         $query = Benefit::with('creator');
 
@@ -43,7 +45,7 @@ class BenefitController extends Controller
         ]);
     }
 
-    public function store(StoreBenefitRequest $request)
+    public function store(StoreBenefitRequest $request): RedirectResponse
     {
         $data = $request->validated();
 
@@ -69,7 +71,7 @@ class BenefitController extends Controller
         return redirect()->route('beneficios');
     }
 
-    public function update(UpdateBenefitRequest $request, Benefit $benefit)
+    public function update(UpdateBenefitRequest $request, Benefit $benefit): RedirectResponse
     {
         $data = $request->validated();
 
@@ -108,7 +110,7 @@ class BenefitController extends Controller
         return redirect()->route('beneficios');
     }
 
-    public function destroy(Benefit $benefit)
+    public function destroy(Benefit $benefit): RedirectResponse
     {
         $this->storage->delete(self::IMAGE_DISK, $benefit->image_path);
 

--- a/app/app/Http/Controllers/BenefitController.php
+++ b/app/app/Http/Controllers/BenefitController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreBenefitRequest;

--- a/app/app/Http/Controllers/Controller.php
+++ b/app/app/Http/Controllers/Controller.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 abstract class Controller

--- a/app/app/Http/Controllers/DashboardController.php
+++ b/app/app/Http/Controllers/DashboardController.php
@@ -5,15 +5,17 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Models\Benefit;
+use App\Models\CommunityCenter;
 use App\Models\Delivery;
 use App\Models\Family;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class DashboardController extends Controller
 {
-    public function index(Request $request)
+    public function index(Request $request): Response
     {
         $selectedMonth = (int) $request->input('month', now()->month);
         $selectedYear = (int) $request->input('year', now()->year);
@@ -40,7 +42,7 @@ class DashboardController extends Controller
         $chartData = $this->getChartData($currentStart, $currentEnd, $previousStart, $previousEnd);
         $topItems = $this->getTopItems($currentStart, $currentEnd);
 
-        $communityCenter = \App\Models\CommunityCenter::first();
+        $communityCenter = CommunityCenter::first();
         $lowStockLimit = $communityCenter?->settings['rules']['low_stock_limit'] ?? 50;
 
         $alerts = $this->getStockAlerts($lowStockLimit);

--- a/app/app/Http/Controllers/DashboardController.php
+++ b/app/app/Http/Controllers/DashboardController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Models\Benefit;

--- a/app/app/Http/Controllers/DashboardController.php
+++ b/app/app/Http/Controllers/DashboardController.php
@@ -144,12 +144,14 @@ class DashboardController extends Controller
 
     private function getAvailablePeriods(): array
     {
-        $dates = Delivery::selectRaw('EXTRACT(YEAR FROM delivery_date) as year, EXTRACT(MONTH FROM delivery_date) as month')
+        $dates = Delivery::query()
+            ->select('delivery_date')
             ->distinct()
-            ->orderByDesc('year')
-            ->orderByDesc('month')
-            ->get()
-            ->map(fn ($d) => ['year' => (int) $d->year, 'month' => (int) $d->month])
+            ->orderByDesc('delivery_date')
+            ->pluck('delivery_date')
+            ->map(fn ($date) => ['year' => (int) Carbon::parse($date)->year, 'month' => (int) Carbon::parse($date)->month])
+            ->unique(fn (array $period) => "{$period['year']}-{$period['month']}")
+            ->values()
             ->toArray();
 
         $currentMonth = ['year' => (int) now()->year, 'month' => (int) now()->month];

--- a/app/app/Http/Controllers/DeliveryController.php
+++ b/app/app/Http/Controllers/DeliveryController.php
@@ -12,11 +12,15 @@ use App\Models\StockMovement;
 use App\Services\StorageService;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
+use Inertia\Response as InertiaResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class DeliveryController extends Controller
 {
@@ -46,7 +50,7 @@ class DeliveryController extends Controller
         Cache::increment(self::CACHE_VERSION_KEY);
     }
 
-    public function index(Request $request)
+    public function index(Request $request): InertiaResponse
     {
         $search = $request->input('search');
         $startDate = $this->parseDate($request->input('startDate'));
@@ -111,7 +115,7 @@ class DeliveryController extends Controller
         ]);
     }
 
-    public function store(StoreDeliveryRequest $request)
+    public function store(StoreDeliveryRequest $request): RedirectResponse
     {
         $data = $request->validated();
 
@@ -169,7 +173,7 @@ class DeliveryController extends Controller
             ->with('success', 'Entrega confirmada com sucesso!');
     }
 
-    public function show(Delivery $delivery)
+    public function show(Delivery $delivery): JsonResponse
     {
         $cacheKey = $this->cacheKey("show.{$delivery->id}");
 
@@ -180,7 +184,7 @@ class DeliveryController extends Controller
         });
     }
 
-    public function pdf(Delivery $delivery)
+    public function pdf(Delivery $delivery): Response
     {
         $cacheKey = $this->cacheKey("pdf.{$delivery->id}");
 
@@ -198,7 +202,7 @@ class DeliveryController extends Controller
         ]);
     }
 
-    public function exportPdf(Request $request)
+    public function exportPdf(Request $request): Response
     {
         $type = $request->input('type', 'current_month');
 

--- a/app/app/Http/Controllers/DeliveryController.php
+++ b/app/app/Http/Controllers/DeliveryController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreDeliveryRequest;

--- a/app/app/Http/Controllers/FamilyController.php
+++ b/app/app/Http/Controllers/FamilyController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreFamilyRequest;

--- a/app/app/Http/Controllers/FamilyController.php
+++ b/app/app/Http/Controllers/FamilyController.php
@@ -7,13 +7,16 @@ namespace App\Http\Controllers;
 use App\Http\Requests\StoreFamilyRequest;
 use App\Http\Requests\UpdateFamilyRequest;
 use App\Models\Family;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
+use Inertia\Response;
 
 class FamilyController extends Controller
 {
-    public function index()
+    public function index(): Response
     {
         $search = request('search');
 
@@ -26,6 +29,7 @@ class FamilyController extends Controller
 
         $families->getCollection()->transform(function ($family) {
             $family->total_members_count = ($family->members_count ?? 0) + 1;
+
             return $family;
         });
 
@@ -34,18 +38,18 @@ class FamilyController extends Controller
         ]);
     }
 
-    public function show($id)
+    public function show($id): Response
     {
         $family = Family::with(['address', 'members', 'specificNeeds'])->findOrFail($id);
 
         return Inertia::render('family/[id]/family-info', [
             'backUrl' => url()->previous(),
-            'id'      => $id,
-            'family'  => $family,
+            'id' => $id,
+            'family' => $family,
         ]);
     }
 
-    public function search(Request $request)
+    public function search(Request $request): JsonResponse
     {
         $q = $request->input('q', '');
         $cleanCpf = preg_replace('/\D/', '', $q);
@@ -65,7 +69,7 @@ class FamilyController extends Controller
         return response()->json($families);
     }
 
-    public function edit(Family $family)
+    public function edit(Family $family): Response
     {
         $family->load(['address', 'members']);
 
@@ -74,39 +78,39 @@ class FamilyController extends Controller
         ]);
     }
 
-    public function store(StoreFamilyRequest $request)
+    public function store(StoreFamilyRequest $request): RedirectResponse
     {
         $data = $request->validated();
 
         DB::transaction(function () use ($data) {
             $family = Family::create([
-                'responsible_name'           => $data['name'],
-                'responsible_cpf'            => $data['cpf'],
-                'responsible_birth_date'     => $data['data_nascimento'],
-                'responsible_phone'          => $data['telefone'],
-                'responsible_email'          => $data['email'] ?? null,
-                'income_source'              => $data['fonte_renda'] ?? null,
-                'total_income'               => isset($data['renda_familiar']) ? (int) ($data['renda_familiar'] * 100) : 0,
-                'receives_government_aid'    => ($data['recebe_auxilio'] ?? 'nao') === 'sim',
+                'responsible_name' => $data['name'],
+                'responsible_cpf' => $data['cpf'],
+                'responsible_birth_date' => $data['data_nascimento'],
+                'responsible_phone' => $data['telefone'],
+                'responsible_email' => $data['email'] ?? null,
+                'income_source' => $data['fonte_renda'] ?? null,
+                'total_income' => isset($data['renda_familiar']) ? (int) ($data['renda_familiar'] * 100) : 0,
+                'receives_government_aid' => ($data['recebe_auxilio'] ?? 'nao') === 'sim',
                 'government_aid_description' => $data['auxilios_recebidos'] ?? null,
-                'housing_condition'          => $data['moradia'] ?? null,
-                'general_observations'       => $data['general_observations'] ?? null,
+                'housing_condition' => $data['moradia'] ?? null,
+                'general_observations' => $data['general_observations'] ?? null,
             ]);
 
             $family->address()->create([
-                'zipcode'      => $data['cep'],
-                'street'       => $data['logradouro'],
-                'number'       => $data['numero'],
+                'zipcode' => $data['cep'],
+                'street' => $data['logradouro'],
+                'number' => $data['numero'],
                 'neighborhood' => $data['bairro'],
-                'city'         => $data['cidade'],
-                'state'        => $data['UF'],
+                'city' => $data['cidade'],
+                'state' => $data['UF'],
             ]);
 
             foreach ($data['family_members'] ?? [] as $member) {
                 $family->members()->create([
-                    'name'         => $member['name'],
-                    'cpf'          => $member['cpf'],
-                    'birth_date'   => $member['data_nascimento'],
+                    'name' => $member['name'],
+                    'cpf' => $member['cpf'],
+                    'birth_date' => $member['data_nascimento'],
                     'relationship' => $member['relacao_parentesco'],
                 ]);
             }
@@ -115,34 +119,34 @@ class FamilyController extends Controller
         return redirect()->route('family');
     }
 
-    public function update(UpdateFamilyRequest $request, Family $family)
+    public function update(UpdateFamilyRequest $request, Family $family): RedirectResponse
     {
         $data = $request->validated();
 
         DB::transaction(function () use ($data, $family) {
             $family->update([
-                'responsible_name'           => $data['name'],
-                'responsible_cpf'            => $data['cpf'],
-                'responsible_birth_date'     => $data['data_nascimento'],
-                'responsible_phone'          => $data['telefone'],
-                'responsible_email'          => $data['email'] ?? null,
-                'income_source'              => $data['fonte_renda'] ?? null,
-                'total_income'               => isset($data['renda_familiar']) ? (int) ($data['renda_familiar'] * 100) : 0,
-                'receives_government_aid'    => ($data['recebe_auxilio'] ?? 'nao') === 'sim',
+                'responsible_name' => $data['name'],
+                'responsible_cpf' => $data['cpf'],
+                'responsible_birth_date' => $data['data_nascimento'],
+                'responsible_phone' => $data['telefone'],
+                'responsible_email' => $data['email'] ?? null,
+                'income_source' => $data['fonte_renda'] ?? null,
+                'total_income' => isset($data['renda_familiar']) ? (int) ($data['renda_familiar'] * 100) : 0,
+                'receives_government_aid' => ($data['recebe_auxilio'] ?? 'nao') === 'sim',
                 'government_aid_description' => $data['auxilios_recebidos'] ?? null,
-                'housing_condition'          => $data['moradia'] ?? null,
-                'general_observations'       => $data['general_observations'] ?? null,
+                'housing_condition' => $data['moradia'] ?? null,
+                'general_observations' => $data['general_observations'] ?? null,
             ]);
 
             $family->address()->updateOrCreate(
                 ['family_id' => $family->id],
                 [
-                    'zipcode'      => $data['cep'],
-                    'street'       => $data['logradouro'],
-                    'number'       => $data['numero'],
+                    'zipcode' => $data['cep'],
+                    'street' => $data['logradouro'],
+                    'number' => $data['numero'],
                     'neighborhood' => $data['bairro'],
-                    'city'         => $data['cidade'],
-                    'state'        => $data['UF'],
+                    'city' => $data['cidade'],
+                    'state' => $data['UF'],
                 ]
             );
 
@@ -150,9 +154,9 @@ class FamilyController extends Controller
 
             foreach ($data['family_members'] ?? [] as $member) {
                 $family->members()->create([
-                    'name'         => $member['name'],
-                    'cpf'          => $member['cpf'] ?? null,
-                    'birth_date'   => $member['data_nascimento'],
+                    'name' => $member['name'],
+                    'cpf' => $member['cpf'] ?? null,
+                    'birth_date' => $member['data_nascimento'],
                     'relationship' => $member['relacao_parentesco'],
                 ]);
             }
@@ -161,14 +165,14 @@ class FamilyController extends Controller
         return redirect()->route('family.info', $family->id);
     }
 
-    public function deactivate(Family $family)
+    public function deactivate(Family $family): RedirectResponse
     {
         $family->update(['is_active' => false]);
 
         return redirect()->route('family');
     }
 
-    public function activate(Family $family)
+    public function activate(Family $family): RedirectResponse
     {
         $family->update(['is_active' => true]);
 

--- a/app/app/Http/Controllers/Landing/landingPageController.php
+++ b/app/app/Http/Controllers/Landing/landingPageController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers;
 
 abstract class Controller

--- a/app/app/Http/Controllers/Settings/PasswordController.php
+++ b/app/app/Http/Controllers/Settings/PasswordController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Controllers/Settings/ProfileController.php
+++ b/app/app/Http/Controllers/Settings/ProfileController.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Controllers\Settings;
 
 use App\Http\Controllers\Controller;

--- a/app/app/Http/Middleware/CheckRole.php
+++ b/app/app/Http/Middleware/CheckRole.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware;
 
 use Closure;

--- a/app/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/app/Http/Middleware/HandleInertiaRequests.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware;
 
 use App\Models\CommunityCenter;

--- a/app/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/app/Http/Requests/Auth/LoginRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Auth;
 
 use Illuminate\Auth\Events\Lockout;

--- a/app/app/Http/Requests/Settings/ProfileUpdateRequest.php
+++ b/app/app/Http/Requests/Settings/ProfileUpdateRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\Settings;
 
 use App\Models\User;

--- a/app/app/Http/Requests/StoreBenefitRequest.php
+++ b/app/app/Http/Requests/StoreBenefitRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/app/Http/Requests/StoreDeliveryRequest.php
+++ b/app/app/Http/Requests/StoreDeliveryRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/app/Http/Requests/StoreFamilyRequest.php
+++ b/app/app/Http/Requests/StoreFamilyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/app/Http/Requests/UpdateBenefitRequest.php
+++ b/app/app/Http/Requests/UpdateBenefitRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/app/Http/Requests/UpdateFamilyRequest.php
+++ b/app/app/Http/Requests/UpdateFamilyRequest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;

--- a/app/app/Models/Address.php
+++ b/app/app/Models/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/app/Models/Address.php
+++ b/app/app/Models/Address.php
@@ -11,7 +11,15 @@ class Address extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'family_id',
+        'zipcode',
+        'street',
+        'number',
+        'neighborhood',
+        'city',
+        'state',
+    ];
 
     public function family()
     {

--- a/app/app/Models/Benefit.php
+++ b/app/app/Models/Benefit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use App\Services\StorageService;

--- a/app/app/Models/Benefit.php
+++ b/app/app/Models/Benefit.php
@@ -12,7 +12,18 @@ class Benefit extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'code',
+        'name',
+        'category',
+        'stock',
+        'status',
+        'donor',
+        'validity',
+        'notes',
+        'image_path',
+        'created_by',
+    ];
 
     protected $casts = [
         'stock' => 'integer',

--- a/app/app/Models/CommunityCenter.php
+++ b/app/app/Models/CommunityCenter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use App\Services\StorageService;

--- a/app/app/Models/Delivery.php
+++ b/app/app/Models/Delivery.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use App\Services\StorageService;

--- a/app/app/Models/Delivery.php
+++ b/app/app/Models/Delivery.php
@@ -12,7 +12,18 @@ class Delivery extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'code',
+        'family_id',
+        'benefit_id',
+        'quantity',
+        'location',
+        'delivery_date',
+        'notes',
+        'receipt_path',
+        'delivered_by',
+        'status',
+    ];
 
     protected $casts = [
         'delivery_date' => 'date',

--- a/app/app/Models/Family.php
+++ b/app/app/Models/Family.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/app/Models/Family.php
+++ b/app/app/Models/Family.php
@@ -11,7 +11,20 @@ class Family extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'responsible_name',
+        'responsible_cpf',
+        'responsible_birth_date',
+        'responsible_phone',
+        'responsible_email',
+        'is_active',
+        'total_income',
+        'income_source',
+        'receives_government_aid',
+        'government_aid_description',
+        'housing_condition',
+        'general_observations',
+    ];
 
     protected $casts = [
         'responsible_birth_date' => 'date',

--- a/app/app/Models/FamilyMember.php
+++ b/app/app/Models/FamilyMember.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/app/Models/FamilyMember.php
+++ b/app/app/Models/FamilyMember.php
@@ -11,7 +11,13 @@ class FamilyMember extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'family_id',
+        'name',
+        'birth_date',
+        'relationship',
+        'cpf',
+    ];
 
     protected $casts = [
         'birth_date' => 'date',

--- a/app/app/Models/SocialLink.php
+++ b/app/app/Models/SocialLink.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;

--- a/app/app/Models/SpecificNeed.php
+++ b/app/app/Models/SpecificNeed.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/app/Models/StockMovement.php
+++ b/app/app/Models/StockMovement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;

--- a/app/app/Models/StockMovement.php
+++ b/app/app/Models/StockMovement.php
@@ -11,7 +11,15 @@ class StockMovement extends Model
 {
     use HasFactory;
 
-    protected $guarded = ['id'];
+    protected $fillable = [
+        'benefit_id',
+        'quantity',
+        'type',
+        'reference_type',
+        'reference_id',
+        'created_by',
+        'reason',
+    ];
 
     protected $casts = [
         'quantity' => 'integer',

--- a/app/app/Models/User.php
+++ b/app/app/Models/User.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use App\Enums\UserRole;

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Models\CommunityCenter;
 use App\Services\StorageService;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 
@@ -24,6 +25,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Model::preventSilentlyDiscardingAttributes();
+
         View::composer('app', function ($view) {
             $view->with('communityCenter', CommunityCenter::first());
         });

--- a/app/app/Providers/AppServiceProvider.php
+++ b/app/app/Providers/AppServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Providers;
 
 use App\Models\CommunityCenter;

--- a/app/app/Services/MensageriaService.php
+++ b/app/app/Services/MensageriaService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use App\Constants\Messages;

--- a/app/app/Services/StorageService.php
+++ b/app/app/Services/StorageService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use Illuminate\Http\UploadedFile;

--- a/app/tests/Feature/DeliveryTest.php
+++ b/app/tests/Feature/DeliveryTest.php
@@ -78,6 +78,7 @@ class DeliveryTest extends TestCase
 
         $response = $this->withSession(['_token' => 'test-token'])
             ->actingAs($user)
+            ->from('/entregas')
             ->post('/entregas', [
                 '_token' => 'test-token',
             'family_id' => $family->id,
@@ -85,7 +86,7 @@ class DeliveryTest extends TestCase
             'quantity' => 5,
             'delivery_date' => now()->format('Y-m-d'),
             'location' => 'Centro Comunitário A',
-        ]);
+            ]);
 
         $response->assertRedirect('/entregas');
         $response->assertSessionHasErrors(['quantity' => 'Estoque insuficiente para este benefício.']);


### PR DESCRIPTION
## Resumo

Primeira parte da refatoração do lado PHP (Tema A — **base de tipos e segurança**).
Mudanças mecânicas, sem alteração de comportamento, que deixam o codebase mais
rígido e preparado para os próximos passos (enums de domínio e testes do
`FamilyController`).

A suíte de testes está **100% verde (54/54)** — incluindo 2 testes que já
vinham falhando antes deste PR.

## O que foi feito

### `declare(strict_types=1)` em todo `app/app/`
Adicionado em **todos os 46 arquivos PHP** (Models, Casts, Enums, Constants,
Providers, Services, Console, Controllers, Requests e Middleware), incluindo o
scaffolding do Laravel Breeze.

### Mass-assignment explícito (`$fillable`)
- 6 models (`Benefit`, `Delivery`, `Family`, `FamilyMember`, `Address`,
  `StockMovement`) trocaram `$guarded = ['id']` por `$fillable` com todas as
  colunas de dados. Os outros 4 models já usavam `$fillable`.
- Ativado `Model::preventSilentlyDiscardingAttributes()` no `AppServiceProvider`
  como rede de segurança — mass-assignment em colunas fora do `$fillable` agora
  lança exceção em vez de falhar silenciosamente.

### Return types explícitos nos controllers
- Controllers de nível superior (`BenefitController`, `DashboardController`,
  `DeliveryController`, `FamilyController`) e Admin (`AppearanceController`,
  `ConfiguracoesGeraisController`, `PageCustomizationController`) receberam
  return types (`Response`, `RedirectResponse`, `JsonResponse`).
- Controllers de Auth/Settings, FormRequests e Middleware **já tinham** return
  types (são scaffolding do Breeze).

### Cast `MaskedCpf` tipado
`get()` e `set()` receberam assinaturas completas de parâmetros e retorno,
alinhadas ao contrato `CastsAttributes`.

## Bônus: correção de 2 testes que já falhavam

| Teste | Causa | Correção |
|---|---|---|
| `DashboardTest::test_authenticated_users_can_visit_the_dashboard` | `getAvailablePeriods()` usava `EXTRACT(YEAR FROM ...)` (sintaxe PostgreSQL/MySQL), quebrando no SQLite dos testes | Trocado por `select distinct delivery_date` + extração de ano/mês via Carbon (compatível com ambos os bancos) |
| `DeliveryTest::test_delivery_fails_when_stock_is_insufficient` | O caminho de erro de validação usa `redirect()->back()`; sem URL anterior o teste redirecionava para `/` em vez de `/entregas` | Adicionado `->from('/entregas')` no teste para simular o envio a partir da página de entregas |

## Como testar

```bash
docker exec centelha-php sh -c 'cd /var/www/html && ./vendor/bin/phpunit'
# => OK (54 tests, 154 assertions)

docker exec centelha-php sh -c 'cd /var/www/html && ./vendor/bin/pint --test'