### PR TITLE
test(php): adicionar cobertura de testes para o modulo de familia

### DIFF
--- a/app/app/Constants/Messages.php
+++ b/app/app/Constants/Messages.php
@@ -8,25 +8,42 @@ class Messages
 {
     // Autenticação
     const MSG_01 = 'Login realizado com sucesso!';
+
     const MSG_02 = 'E-mail de recuperação enviado!';
+
     const MSG_03 = 'Senha alterada com sucesso!';
+
     const MSG_04 = 'E-mail ou senha incorretos.';
+
     const MSG_05 = 'Verifique o e-mail informado.';
+
     const MSG_06 = 'Link de recuperação inválido ou expirado.';
+
     const MSG_07 = 'Senhas não coincidem.';
+
     const MSG_08 = 'Verifique sua conexão de Internet.';
+
     const MSG_09 = 'Conta Desativada.';
+
     const MSG_10 = 'Aguarde 30 segundos e tente novamente.';
+
     const MSG_11 = 'Um link de redefinição será enviado para o e-mail informado.';
+
     const MSG_12 = 'Token Expirado.';
+
     const MSG_13 = 'Token Inválido.';
 
     // Família
     const MSG_14 = 'Informações da família atualizadas com sucesso.';
+
     const MSG_15 = 'Campo inválido.';
+
     const MSG_16 = 'Cadastro realizado com sucesso!';
+
     const MSG_17 = 'Este CPF já está cadastrado no sistema.';
+
     const MSG_18 = 'Informações da família atualizadas com sucesso.';
+
     const MSG_19 = 'Família desativada com sucesso.';
 
     public static array $types = [

--- a/app/app/Constants/Messages.php
+++ b/app/app/Constants/Messages.php
@@ -46,6 +46,8 @@ class Messages
 
     const MSG_19 = 'Família desativada com sucesso.';
 
+    const MSG_20 = 'Família ativada com sucesso.';
+
     public static array $types = [
         self::MSG_01 => 'success',
         self::MSG_02 => 'success',
@@ -66,6 +68,7 @@ class Messages
         self::MSG_17 => 'error',
         self::MSG_18 => 'success',
         self::MSG_19 => 'success',
+        self::MSG_20 => 'success',
     ];
 
     public static function type(string $message): string

--- a/app/app/Http/Controllers/Auth/NewPasswordController.php
+++ b/app/app/Http/Controllers/Auth/NewPasswordController.php
@@ -32,7 +32,7 @@ class NewPasswordController extends Controller
     /**
      * Handle an incoming new password request.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request): RedirectResponse
     {

--- a/app/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -26,7 +27,7 @@ class PasswordResetLinkController extends Controller
     /**
      * Handle an incoming password reset link request.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request): RedirectResponse
     {

--- a/app/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -28,7 +29,7 @@ class RegisteredUserController extends Controller
     /**
      * Handle an incoming registration request.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function store(Request $request): RedirectResponse
     {

--- a/app/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Auth\Events\Verified;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 use Illuminate\Http\RedirectResponse;
 
@@ -21,7 +22,7 @@ class VerifyEmailController extends Controller
         }
 
         if ($request->user()->markEmailAsVerified()) {
-            /** @var \Illuminate\Contracts\Auth\MustVerifyEmail $user */
+            /** @var MustVerifyEmail $user */
             $user = $request->user();
 
             event(new Verified($user));

--- a/app/app/Http/Controllers/FamilyController.php
+++ b/app/app/Http/Controllers/FamilyController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Constants\Messages;
 use App\Http\Requests\StoreFamilyRequest;
 use App\Http\Requests\UpdateFamilyRequest;
 use App\Models\Family;
@@ -116,7 +117,7 @@ class FamilyController extends Controller
             }
         });
 
-        return redirect()->route('family');
+        return redirect()->route('family')->with('success', Messages::MSG_16);
     }
 
     public function update(UpdateFamilyRequest $request, Family $family): RedirectResponse
@@ -162,20 +163,20 @@ class FamilyController extends Controller
             }
         });
 
-        return redirect()->route('family.info', $family->id);
+        return redirect()->route('family.info', $family->id)->with('success', Messages::MSG_14);
     }
 
     public function deactivate(Family $family): RedirectResponse
     {
         $family->update(['is_active' => false]);
 
-        return redirect()->route('family');
+        return redirect()->route('family')->with('success', Messages::MSG_19);
     }
 
     public function activate(Family $family): RedirectResponse
     {
         $family->update(['is_active' => true]);
 
-        return redirect()->route('family');
+        return redirect()->route('family')->with('success', Messages::MSG_20);
     }
 }

--- a/app/app/Http/Controllers/Landing/landingPageController.php
+++ b/app/app/Http/Controllers/Landing/landingPageController.php
@@ -4,7 +4,4 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
-abstract class Controller
-{
-    
-}
+abstract class Controller {}

--- a/app/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/app/Http/Middleware/HandleInertiaRequests.php
@@ -56,8 +56,8 @@ class HandleInertiaRequests extends Middleware
 
             'flash' => [
                 'success' => $request->session()->get('success'),
-                'error'   => $request->session()->get('error'),
-                'msg'     => $request->session()->get('msg'),
+                'error' => $request->session()->get('error'),
+                'msg' => $request->session()->get('msg'),
                 'msgType' => $request->session()->get('msgType'),
             ],
         ];

--- a/app/app/Http/Requests/Auth/LoginRequest.php
+++ b/app/app/Http/Requests/Auth/LoginRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Requests\Auth;
 
 use Illuminate\Auth\Events\Lockout;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\RateLimiter;
@@ -24,7 +25,7 @@ class LoginRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
@@ -37,7 +38,7 @@ class LoginRequest extends FormRequest
     /**
      * Attempt to authenticate the request's credentials.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function authenticate(): void
     {
@@ -65,7 +66,7 @@ class LoginRequest extends FormRequest
     /**
      * Ensure the login request is not rate limited.
      *
-     * @throws \Illuminate\Validation\ValidationException
+     * @throws ValidationException
      */
     public function ensureIsNotRateLimited(): void
     {

--- a/app/app/Http/Requests/StoreFamilyRequest.php
+++ b/app/app/Http/Requests/StoreFamilyRequest.php
@@ -16,30 +16,30 @@ class StoreFamilyRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name'                                => ['required', 'string', 'max:255'],
-            'cpf'                                 => ['required', 'string', 'size:11', 'unique:families,responsible_cpf'],
-            'telefone'                            => ['required', 'string', 'min:10', 'max:11'],
-            'email'                               => ['nullable', 'email', 'max:255'],
-            'data_nascimento'                     => ['required', 'date', 'before:18 years ago'],
+            'name' => ['required', 'string', 'max:255'],
+            'cpf' => ['required', 'string', 'size:11', 'unique:families,responsible_cpf'],
+            'telefone' => ['required', 'string', 'min:10', 'max:11'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'data_nascimento' => ['required', 'date', 'before:18 years ago'],
 
-            'cep'                                 => ['required', 'string', 'size:8'],
-            'logradouro'                          => ['required', 'string', 'max:255'],
-            'numero'                              => ['required', 'string', 'max:20'],
-            'cidade'                              => ['required', 'string', 'max:100'],
-            'UF'                                  => ['required', 'string', 'size:2'],
-            'bairro'                              => ['required', 'string', 'max:100'],
-            'moradia'                             => ['nullable', 'string', 'in:propria,alugada,cedida'],
+            'cep' => ['required', 'string', 'size:8'],
+            'logradouro' => ['required', 'string', 'max:255'],
+            'numero' => ['required', 'string', 'max:20'],
+            'cidade' => ['required', 'string', 'max:100'],
+            'UF' => ['required', 'string', 'size:2'],
+            'bairro' => ['required', 'string', 'max:100'],
+            'moradia' => ['nullable', 'string', 'in:propria,alugada,cedida'],
 
-            'fonte_renda'                         => ['nullable', 'string', 'max:50'],
-            'renda_familiar'                      => ['nullable', 'numeric', 'min:0', 'max:3500'],
-            'recebe_auxilio'                      => ['nullable', 'string', 'in:sim,nao'],
-            'auxilios_recebidos'                  => ['nullable', 'string', 'max:255'],
-            'general_observations'                => ['nullable', 'string', 'max:1000'],
+            'fonte_renda' => ['nullable', 'string', 'max:50'],
+            'renda_familiar' => ['nullable', 'numeric', 'min:0', 'max:3500'],
+            'recebe_auxilio' => ['nullable', 'string', 'in:sim,nao'],
+            'auxilios_recebidos' => ['nullable', 'string', 'max:255'],
+            'general_observations' => ['nullable', 'string', 'max:1000'],
 
-            'family_members'                      => ['nullable', 'array'],
-            'family_members.*.name'               => ['required', 'string', 'max:100'],
-            'family_members.*.cpf'                => ['required', 'string', 'size:11'],
-            'family_members.*.data_nascimento'    => ['required', 'date'],
+            'family_members' => ['nullable', 'array'],
+            'family_members.*.name' => ['required', 'string', 'max:100'],
+            'family_members.*.cpf' => ['required', 'string', 'size:11'],
+            'family_members.*.data_nascimento' => ['required', 'date'],
             'family_members.*.relacao_parentesco' => ['required', 'string', 'max:50'],
         ];
     }
@@ -47,25 +47,25 @@ class StoreFamilyRequest extends FormRequest
     protected function prepareForValidation(): void
     {
         $this->merge([
-            'cpf'      => preg_replace('/\D/', '', $this->cpf ?? ''),
+            'cpf' => preg_replace('/\D/', '', $this->cpf ?? ''),
             'telefone' => preg_replace('/\D/', '', $this->telefone ?? ''),
-            'cep'      => preg_replace('/\D/', '', $this->cep ?? ''),
+            'cep' => preg_replace('/\D/', '', $this->cep ?? ''),
         ]);
     }
 
     public function messages(): array
     {
         return [
-            'cpf.unique'                 => 'Este CPF já está cadastrado no sistema.',
-            'name.required'              => 'O nome do responsável é obrigatório.',
-            'data_nascimento.required'   => 'A data de nascimento é obrigatória.',
-            'data_nascimento.before'     => 'O responsável deve ter pelo menos 18 anos.',
-            'cep.required'               => 'O CEP é obrigatório.',
-            'logradouro.required'        => 'O logradouro é obrigatório.',
-            'numero.required'            => 'O número é obrigatório.',
-            'cidade.required'            => 'A cidade é obrigatória.',
-            'UF.required'                => 'O estado (UF) é obrigatório.',
-            'bairro.required'            => 'O bairro é obrigatório.',
+            'cpf.unique' => 'Este CPF já está cadastrado no sistema.',
+            'name.required' => 'O nome do responsável é obrigatório.',
+            'data_nascimento.required' => 'A data de nascimento é obrigatória.',
+            'data_nascimento.before' => 'O responsável deve ter pelo menos 18 anos.',
+            'cep.required' => 'O CEP é obrigatório.',
+            'logradouro.required' => 'O logradouro é obrigatório.',
+            'numero.required' => 'O número é obrigatório.',
+            'cidade.required' => 'A cidade é obrigatória.',
+            'UF.required' => 'O estado (UF) é obrigatório.',
+            'bairro.required' => 'O bairro é obrigatório.',
         ];
     }
 }

--- a/app/app/Http/Requests/UpdateFamilyRequest.php
+++ b/app/app/Http/Requests/UpdateFamilyRequest.php
@@ -19,30 +19,30 @@ class UpdateFamilyRequest extends FormRequest
         $family = $this->route('family');
 
         return [
-            'name'                                => ['required', 'string', 'max:255'],
-            'cpf'                                 => ['required', 'string', 'size:11', Rule::unique('families', 'responsible_cpf')->ignore($family)],
-            'telefone'                            => ['required', 'string', 'min:10', 'max:11'],
-            'email'                               => ['nullable', 'email', 'max:255'],
-            'data_nascimento'                     => ['required', 'date', 'before:18 years ago'],
+            'name' => ['required', 'string', 'max:255'],
+            'cpf' => ['required', 'string', 'size:11', Rule::unique('families', 'responsible_cpf')->ignore($family)],
+            'telefone' => ['required', 'string', 'min:10', 'max:11'],
+            'email' => ['nullable', 'email', 'max:255'],
+            'data_nascimento' => ['required', 'date', 'before:18 years ago'],
 
-            'cep'                                 => ['required', 'string', 'size:8'],
-            'logradouro'                          => ['required', 'string', 'max:255'],
-            'numero'                              => ['required', 'string', 'max:20'],
-            'cidade'                              => ['required', 'string', 'max:100'],
-            'UF'                                  => ['required', 'string', 'size:2'],
-            'bairro'                              => ['required', 'string', 'max:100'],
-            'moradia'                             => ['nullable', 'string', 'in:propria,alugada,cedida'],
+            'cep' => ['required', 'string', 'size:8'],
+            'logradouro' => ['required', 'string', 'max:255'],
+            'numero' => ['required', 'string', 'max:20'],
+            'cidade' => ['required', 'string', 'max:100'],
+            'UF' => ['required', 'string', 'size:2'],
+            'bairro' => ['required', 'string', 'max:100'],
+            'moradia' => ['nullable', 'string', 'in:propria,alugada,cedida'],
 
-            'fonte_renda'                         => ['nullable', 'string', 'max:50'],
-            'renda_familiar'                      => ['nullable', 'numeric', 'min:0', 'max:3500'],
-            'recebe_auxilio'                      => ['nullable', 'string', 'in:sim,nao'],
-            'auxilios_recebidos'                  => ['nullable', 'string', 'max:255'],
-            'general_observations'                => ['nullable', 'string', 'max:1000'],
+            'fonte_renda' => ['nullable', 'string', 'max:50'],
+            'renda_familiar' => ['nullable', 'numeric', 'min:0', 'max:3500'],
+            'recebe_auxilio' => ['nullable', 'string', 'in:sim,nao'],
+            'auxilios_recebidos' => ['nullable', 'string', 'max:255'],
+            'general_observations' => ['nullable', 'string', 'max:1000'],
 
-            'family_members'                      => ['nullable', 'array'],
-            'family_members.*.name'               => ['required', 'string', 'max:100'],
-            'family_members.*.cpf'                => ['nullable', 'string', 'size:11'],
-            'family_members.*.data_nascimento'    => ['required', 'date'],
+            'family_members' => ['nullable', 'array'],
+            'family_members.*.name' => ['required', 'string', 'max:100'],
+            'family_members.*.cpf' => ['nullable', 'string', 'size:11'],
+            'family_members.*.data_nascimento' => ['required', 'date'],
             'family_members.*.relacao_parentesco' => ['required', 'string', 'max:50'],
         ];
     }
@@ -50,17 +50,17 @@ class UpdateFamilyRequest extends FormRequest
     protected function prepareForValidation(): void
     {
         $this->merge([
-            'cpf'      => preg_replace('/\D/', '', $this->cpf ?? ''),
+            'cpf' => preg_replace('/\D/', '', $this->cpf ?? ''),
             'telefone' => preg_replace('/\D/', '', $this->telefone ?? ''),
-            'cep'      => preg_replace('/\D/', '', $this->cep ?? ''),
+            'cep' => preg_replace('/\D/', '', $this->cep ?? ''),
         ]);
     }
 
     public function messages(): array
     {
         return [
-            'cpf.unique'                 => 'Este CPF já está cadastrado para outra família.',
-            'data_nascimento.before'     => 'O responsável deve ter pelo menos 18 anos.',
+            'cpf.unique' => 'Este CPF já está cadastrado para outra família.',
+            'data_nascimento.before' => 'O responsável deve ter pelo menos 18 anos.',
         ];
     }
 }

--- a/app/app/Models/Family.php
+++ b/app/app/Models/Family.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Casts\MaskedCpf;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -31,8 +32,9 @@ class Family extends Model
         'is_active' => 'boolean',
         'receives_government_aid' => 'boolean',
         'total_income' => 'integer',
-        'responsible_cpf' => \App\Casts\MaskedCpf::class,
+        'responsible_cpf' => MaskedCpf::class,
     ];
+
     public function address()
     {
         return $this->hasOne(Address::class);

--- a/app/app/Models/FamilyMember.php
+++ b/app/app/Models/FamilyMember.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Casts\MaskedCpf;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -21,8 +22,9 @@ class FamilyMember extends Model
 
     protected $casts = [
         'birth_date' => 'date',
-        'cpf' => \App\Casts\MaskedCpf::class,
+        'cpf' => MaskedCpf::class,
     ];
+
     public function family()
     {
         return $this->belongsTo(Family::class);

--- a/app/app/Services/MensageriaService.php
+++ b/app/app/Services/MensageriaService.php
@@ -51,6 +51,7 @@ class MensageriaService
                 return str_replace('_', '-', $name);
             }
         }
+
         return null;
     }
 }

--- a/app/bootstrap/app.php
+++ b/app/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\CheckRole;
 use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -19,7 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
 
         $middleware->alias([
-            'role' => \App\Http\Middleware\CheckRole::class,
+            'role' => CheckRole::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/app/bootstrap/providers.php
+++ b/app/bootstrap/providers.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+
 return [
-    App\Providers\AppServiceProvider::class,
+    AppServiceProvider::class,
 ];

--- a/app/config/auth.php
+++ b/app/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
 
     /*
@@ -62,7 +64,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', User::class),
         ],
 
         // 'users' => [

--- a/app/database/factories/DeliveryFactory.php
+++ b/app/database/factories/DeliveryFactory.php
@@ -15,7 +15,7 @@ class DeliveryFactory extends Factory
     public function definition(): array
     {
         return [
-            'code' => 'ENT-' . str_pad((string) $this->faker->unique()->numberBetween(1, 9999), 4, '0', STR_PAD_LEFT),
+            'code' => 'ENT-'.str_pad((string) $this->faker->unique()->numberBetween(1, 9999), 4, '0', STR_PAD_LEFT),
             'family_id' => Family::factory(),
             'benefit_id' => Benefit::factory(),
             'quantity' => $this->faker->numberBetween(1, 5),

--- a/app/database/factories/FamilyFactory.php
+++ b/app/database/factories/FamilyFactory.php
@@ -9,6 +9,7 @@ class FamilyFactory extends Factory
     public function definition(): array
     {
         $aid = fake()->boolean(60);
+
         return [
             'responsible_name' => fake()->name(),
             'responsible_cpf' => fake()->unique()->numerify('###.###.###-##'),

--- a/app/database/factories/UserFactory.php
+++ b/app/database/factories/UserFactory.php
@@ -2,12 +2,13 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {

--- a/app/database/migrations/2026_05_28_175332_create_families_table.php
+++ b/app/database/migrations/2026_05_28_175332_create_families_table.php
@@ -17,14 +17,14 @@ return new class extends Migration
             $table->string('responsible_phone');
             $table->string('responsible_email')->nullable();
             $table->boolean('is_active')->default(true);
-            
+
             // Dados Socioeconômicos
             $table->integer('total_income')->default(0); // Valor em centavos
             $table->string('income_source')->nullable(); // Ex: Informal, Formal
             $table->boolean('receives_government_aid')->default(false);
             $table->string('government_aid_description')->nullable(); // Ex: Bolsa Família
             $table->string('housing_condition')->nullable(); // Própria, Alugada, Ocupação
-            
+
             // Observações Gerais
             $table->text('general_observations')->nullable();
             $table->timestamps();

--- a/app/database/migrations/2026_05_28_182539_create_addresses_table.php
+++ b/app/database/migrations/2026_05_28_182539_create_addresses_table.php
@@ -11,14 +11,14 @@ return new class extends Migration
         Schema::create('addresses', function (Blueprint $table) {
             $table->id();
             $table->foreignId('family_id')->constrained('families')->cascadeOnDelete();
-            
+
             $table->string('zipcode', 10)->nullable();
             $table->string('street');
             $table->string('number')->nullable();
             $table->string('neighborhood');
             $table->string('city');
             $table->string('state', 2); // UF, ex: SP, RJ
-            
+
             $table->timestamps();
         });
     }

--- a/app/database/seeders/AddressSeeder.php
+++ b/app/database/seeders/AddressSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class AddressSeeder extends Seeder

--- a/app/database/seeders/FamilyMemberSeeder.php
+++ b/app/database/seeders/FamilyMemberSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class FamilyMemberSeeder extends Seeder

--- a/app/database/seeders/FamilySeeder.php
+++ b/app/database/seeders/FamilySeeder.php
@@ -2,11 +2,11 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Seeder;
+use App\Models\Address;
 use App\Models\Family;
 use App\Models\FamilyMember;
 use App\Models\SpecificNeed;
-use App\Models\Address;
+use Illuminate\Database\Seeder;
 
 class FamilySeeder extends Seeder
 {
@@ -19,7 +19,7 @@ class FamilySeeder extends Seeder
             'Necessidade de Fraldas (Geriátrica)',
             'PCD / Mobilidade Reduzida',
             'Gestante',
-            'Acamado'
+            'Acamado',
         ];
 
         $specificNeeds = collect();
@@ -38,10 +38,10 @@ class FamilySeeder extends Seeder
             )
             ->has(
                 FamilyMember::factory()
-                ->count(rand(1, 4))
-                ->state(function (array $attributes, Family $family) {
-                    return ['family_id' => $family->id];
-                }),
+                    ->count(rand(1, 4))
+                    ->state(function (array $attributes, Family $family) {
+                        return ['family_id' => $family->id];
+                    }),
                 'members'
             )
             ->create()

--- a/app/database/seeders/SpecificNeedSeeder.php
+++ b/app/database/seeders/SpecificNeedSeeder.php
@@ -2,7 +2,6 @@
 
 namespace Database\Seeders;
 
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class SpecificNeedSeeder extends Seeder

--- a/app/tests/Feature/DeliveryTest.php
+++ b/app/tests/Feature/DeliveryTest.php
@@ -44,13 +44,13 @@ class DeliveryTest extends TestCase
             ->actingAs($user)
             ->post('/entregas', [
                 '_token' => 'test-token',
-            'family_id' => $family->id,
-            'benefit_id' => $benefit->id,
-            'quantity' => 3,
-            'delivery_date' => now()->format('Y-m-d'),
-            'location' => 'Centro Comunitário A',
-            'notes' => 'Observação de teste',
-        ]);
+                'family_id' => $family->id,
+                'benefit_id' => $benefit->id,
+                'quantity' => 3,
+                'delivery_date' => now()->format('Y-m-d'),
+                'location' => 'Centro Comunitário A',
+                'notes' => 'Observação de teste',
+            ]);
 
         $response->assertRedirect('/entregas');
 
@@ -81,11 +81,11 @@ class DeliveryTest extends TestCase
             ->from('/entregas')
             ->post('/entregas', [
                 '_token' => 'test-token',
-            'family_id' => $family->id,
-            'benefit_id' => $benefit->id,
-            'quantity' => 5,
-            'delivery_date' => now()->format('Y-m-d'),
-            'location' => 'Centro Comunitário A',
+                'family_id' => $family->id,
+                'benefit_id' => $benefit->id,
+                'quantity' => 5,
+                'delivery_date' => now()->format('Y-m-d'),
+                'location' => 'Centro Comunitário A',
             ]);
 
         $response->assertRedirect('/entregas');
@@ -132,13 +132,13 @@ class DeliveryTest extends TestCase
             ->actingAs($user)
             ->post('/entregas', [
                 '_token' => 'test-token',
-            'family_id' => $family->id,
-            'benefit_id' => $benefit->id,
-            'quantity' => 1,
-            'delivery_date' => now()->format('Y-m-d'),
-            'location' => 'Centro Comunitário A',
-            'receipt' => UploadedFile::fake()->create('comprovante.exe', 100, 'application/x-msdownload'),
-        ]);
+                'family_id' => $family->id,
+                'benefit_id' => $benefit->id,
+                'quantity' => 1,
+                'delivery_date' => now()->format('Y-m-d'),
+                'location' => 'Centro Comunitário A',
+                'receipt' => UploadedFile::fake()->create('comprovante.exe', 100, 'application/x-msdownload'),
+            ]);
 
         $response->assertSessionHasErrors(['receipt']);
         $this->assertDatabaseCount('deliveries', 0);

--- a/app/tests/Feature/FamilyAuthTest.php
+++ b/app/tests/Feature/FamilyAuthTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FamilyAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guests_are_redirected_to_login_from_index(): void
+    {
+        $this->get('/family')->assertRedirect('/login');
+    }
+
+    public function test_guests_are_redirected_to_login_from_show(): void
+    {
+        $this->get('/family/details/1')->assertRedirect('/login');
+    }
+
+    public function test_guests_are_redirected_to_login_from_edit(): void
+    {
+        $this->get('/family/1/edit')->assertRedirect('/login');
+    }
+
+    public function test_guests_are_redirected_to_login_from_store(): void
+    {
+        $this->post('/family', ['_token' => 'test-token'])
+            ->assertRedirect('/login');
+    }
+
+    public function test_guests_are_redirected_to_login_from_update(): void
+    {
+        $this->put('/family/1', ['_token' => 'test-token'])
+            ->assertRedirect('/login');
+    }
+
+    public function test_guests_are_redirected_to_login_from_deactivate(): void
+    {
+        $this->patch('/family/1/deactivate', ['_token' => 'test-token'])
+            ->assertRedirect('/login');
+    }
+
+    public function test_guests_are_redirected_to_login_from_activate(): void
+    {
+        $this->patch('/family/1/activate', ['_token' => 'test-token'])
+            ->assertRedirect('/login');
+    }
+
+    public function test_authenticated_users_can_access_family_index(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get('/family')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->component('family/family'));
+    }
+}

--- a/app/tests/Feature/FamilyReadTest.php
+++ b/app/tests/Feature/FamilyReadTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Address;
+use App\Models\Family;
+use App\Models\FamilyMember;
+use App\Models\SpecificNeed;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FamilyReadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_renders_family_listing_page(): void
+    {
+        $user = User::factory()->create();
+        Family::factory()->count(3)->create();
+
+        $this->actingAs($user)
+            ->get('/family')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('family/family')
+                ->has('families.data')
+            );
+    }
+
+    public function test_index_filters_families_by_responsible_name(): void
+    {
+        $user = User::factory()->create();
+        $matching = Family::factory()->create(['responsible_name' => 'João Silva']);
+        Family::factory()->create(['responsible_name' => 'Maria Souza']);
+
+        $response = $this->actingAs($user)->get('/family?search=João');
+
+        $response->assertOk();
+        $response->assertInertia(fn ($page) => $page
+            ->component('family/family')
+            ->has('families.data', 1)
+            ->where('families.data.0.id', $matching->id)
+        );
+    }
+
+    public function test_show_renders_family_info_page(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create();
+        Address::factory()->for($family)->create();
+        FamilyMember::factory()->for($family)->count(2)->create();
+        $needs = SpecificNeed::factory()->count(2)->create();
+        $family->specificNeeds()->attach($needs);
+
+        $this->actingAs($user)
+            ->get("/family/details/{$family->id}")
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('family/[id]/family-info')
+                ->has('id')
+                ->has('backUrl')
+                ->has('family')
+                ->has('family.address')
+                ->has('family.members', 2)
+                ->has('family.specific_needs', 2)
+            );
+    }
+
+    public function test_show_returns_404_for_nonexistent_family(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get('/family/details/9999')
+            ->assertNotFound();
+    }
+
+    public function test_edit_renders_family_form_page(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create();
+        Address::factory()->for($family)->create();
+        FamilyMember::factory()->for($family)->count(2)->create();
+
+        $this->actingAs($user)
+            ->get("/family/{$family->id}/edit")
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('family/form/edit')
+                ->has('family')
+                ->has('family.address')
+                ->has('family.members', 2)
+            );
+    }
+}

--- a/app/tests/Feature/FamilyStateTest.php
+++ b/app/tests/Feature/FamilyStateTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Family;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FamilyStateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_deactivate_flips_is_active_to_false(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create(['is_active' => true]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->patch("/family/{$family->id}/deactivate", ['_token' => 'test-token'])
+            ->assertRedirect('/family');
+
+        $this->assertFalse($family->fresh()->is_active);
+    }
+
+    public function test_activate_flips_is_active_to_true(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create(['is_active' => false]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->patch("/family/{$family->id}/activate", ['_token' => 'test-token'])
+            ->assertRedirect('/family');
+
+        $this->assertTrue($family->fresh()->is_active);
+    }
+
+    public function test_deactivate_returns_404_for_nonexistent_family(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->patch('/family/9999/deactivate', ['_token' => 'test-token'])
+            ->assertNotFound();
+    }
+
+    public function test_activate_returns_404_for_nonexistent_family(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->patch('/family/9999/activate', ['_token' => 'test-token'])
+            ->assertNotFound();
+    }
+}

--- a/app/tests/Feature/FamilyStateTest.php
+++ b/app/tests/Feature/FamilyStateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Constants\Messages;
 use App\Models\Family;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -19,7 +20,8 @@ class FamilyStateTest extends TestCase
         $this->withSession(['_token' => 'test-token'])
             ->actingAs($user)
             ->patch("/family/{$family->id}/deactivate", ['_token' => 'test-token'])
-            ->assertRedirect('/family');
+            ->assertRedirect('/family')
+            ->assertSessionHas('success', Messages::MSG_19);
 
         $this->assertFalse($family->fresh()->is_active);
     }
@@ -32,7 +34,8 @@ class FamilyStateTest extends TestCase
         $this->withSession(['_token' => 'test-token'])
             ->actingAs($user)
             ->patch("/family/{$family->id}/activate", ['_token' => 'test-token'])
-            ->assertRedirect('/family');
+            ->assertRedirect('/family')
+            ->assertSessionHas('success', Messages::MSG_20);
 
         $this->assertTrue($family->fresh()->is_active);
     }

--- a/app/tests/Feature/FamilyValidationTest.php
+++ b/app/tests/Feature/FamilyValidationTest.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Family;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FamilyValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function validFamilyPayload(array $overrides = []): array
+    {
+        return array_merge([
+            '_token' => 'test-token',
+            'name' => 'João Silva',
+            'cpf' => '12345678900',
+            'telefone' => '11999999999',
+            'email' => 'joao@example.com',
+            'data_nascimento' => '1990-01-01',
+            'cep' => '01001000',
+            'logradouro' => 'Rua Teste',
+            'numero' => '123',
+            'cidade' => 'São Paulo',
+            'UF' => 'SP',
+            'bairro' => 'Centro',
+            'moradia' => 'propria',
+            'fonte_renda' => 'Formal',
+            'renda_familiar' => '2500',
+            'recebe_auxilio' => 'sim',
+            'auxilios_recebidos' => 'Bolsa Família',
+            'general_observations' => 'Observação de teste',
+            'family_members' => [
+                [
+                    'name' => 'Maria Silva',
+                    'cpf' => '98765432100',
+                    'data_nascimento' => '2010-05-05',
+                    'relacao_parentesco' => 'Filho(a)',
+                ],
+            ],
+        ], $overrides);
+    }
+
+    public function test_store_requires_name(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload(['name' => '']))
+            ->assertSessionHasErrors(['name']);
+
+        $this->assertDatabaseCount('families', 0);
+    }
+
+    public function test_store_requires_cpf(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload(['cpf' => '']))
+            ->assertSessionHasErrors(['cpf']);
+
+        $this->assertDatabaseCount('families', 0);
+    }
+
+    public function test_store_rejects_cpf_with_wrong_size(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload(['cpf' => '123']))
+            ->assertSessionHasErrors(['cpf']);
+
+        $this->assertDatabaseCount('families', 0);
+    }
+
+    public function test_store_rejects_duplicate_cpf(): void
+    {
+        $user = User::factory()->create();
+        $existing = Family::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload([
+                'cpf' => $existing->getRawOriginal('responsible_cpf'),
+            ]))
+            ->assertSessionHasErrors(['cpf']);
+
+        $this->assertDatabaseCount('families', 1);
+    }
+
+    public function test_store_requires_telefone(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload(['telefone' => '']))
+            ->assertSessionHasErrors(['telefone']);
+    }
+
+    public function test_store_rejects_underage_responsible(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload([
+                'data_nascimento' => now()->subYears(17)->format('Y-m-d'),
+            ]))
+            ->assertSessionHasErrors(['data_nascimento']);
+
+        $this->assertDatabaseCount('families', 0);
+    }
+
+    public function test_store_rejects_invalid_email(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload(['email' => 'not-an-email']))
+            ->assertSessionHasErrors(['email']);
+    }
+
+    public function test_store_requires_address_fields(): void
+    {
+        $user = User::factory()->create();
+
+        $payload = $this->validFamilyPayload([
+            'cep' => '',
+            'logradouro' => '',
+            'numero' => '',
+            'cidade' => '',
+            'UF' => '',
+            'bairro' => '',
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $payload)
+            ->assertSessionHasErrors(['cep', 'logradouro', 'numero', 'cidade', 'UF', 'bairro']);
+
+        $this->assertDatabaseCount('families', 0);
+    }
+
+    public function test_store_rejects_uf_with_wrong_size(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload(['UF' => 'S']))
+            ->assertSessionHasErrors(['UF']);
+    }
+
+    public function test_store_rejects_invalid_moradia_option(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload(['moradia' => 'invalid']))
+            ->assertSessionHasErrors(['moradia']);
+    }
+
+    public function test_store_rejects_renda_familiar_above_maximum(): void
+    {
+        $user = User::factory()->create();
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload(['renda_familiar' => '3501']))
+            ->assertSessionHasErrors(['renda_familiar']);
+
+        $this->assertDatabaseCount('families', 0);
+    }
+
+    public function test_store_rejects_family_member_without_name(): void
+    {
+        $user = User::factory()->create();
+
+        $payload = $this->validFamilyPayload([
+            'family_members' => [
+                [
+                    'name' => '',
+                    'cpf' => '98765432100',
+                    'data_nascimento' => '2010-05-05',
+                    'relacao_parentesco' => 'Filho(a)',
+                ],
+            ],
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $payload)
+            ->assertSessionHasErrors(['family_members.0.name']);
+
+        $this->assertDatabaseCount('families', 0);
+    }
+
+    public function test_store_rejects_family_member_with_invalid_cpf_size(): void
+    {
+        $user = User::factory()->create();
+
+        $payload = $this->validFamilyPayload([
+            'family_members' => [
+                [
+                    'name' => 'Maria Silva',
+                    'cpf' => '123',
+                    'data_nascimento' => '2010-05-05',
+                    'relacao_parentesco' => 'Filho(a)',
+                ],
+            ],
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $payload)
+            ->assertSessionHasErrors(['family_members.0.cpf']);
+
+        $this->assertDatabaseCount('families', 0);
+    }
+
+    public function test_store_normalizes_formatted_input_before_validating(): void
+    {
+        $user = User::factory()->create();
+
+        $payload = $this->validFamilyPayload([
+            'cpf' => '123.456.789-00',
+            'telefone' => '(11) 99999-9999',
+            'cep' => '01001-000',
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $payload)
+            ->assertRedirect('/family');
+
+        $this->assertDatabaseHas('families', [
+            'responsible_cpf' => '12345678900',
+            'responsible_phone' => '11999999999',
+        ]);
+
+        $this->assertDatabaseHas('addresses', [
+            'zipcode' => '01001000',
+        ]);
+    }
+
+    public function test_update_requires_name(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create();
+        $family->address()->create([
+            'zipcode' => '00000000',
+            'street' => 'Old',
+            'number' => '1',
+            'neighborhood' => 'Old',
+            'city' => 'Old',
+            'state' => 'RJ',
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put("/family/{$family->id}", $this->validFamilyPayload([
+                'name' => '',
+                'cpf' => $family->getRawOriginal('responsible_cpf'),
+            ]))
+            ->assertSessionHasErrors(['name']);
+    }
+
+    public function test_update_rejects_cpf_from_another_family(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create();
+        $other = Family::factory()->create();
+        $family->address()->create([
+            'zipcode' => '00000000',
+            'street' => 'Old',
+            'number' => '1',
+            'neighborhood' => 'Old',
+            'city' => 'Old',
+            'state' => 'RJ',
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put("/family/{$family->id}", $this->validFamilyPayload([
+                'cpf' => $other->getRawOriginal('responsible_cpf'),
+            ]))
+            ->assertSessionHasErrors(['cpf']);
+    }
+
+    public function test_update_rejects_underage_responsible(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create();
+        $family->address()->create([
+            'zipcode' => '00000000',
+            'street' => 'Old',
+            'number' => '1',
+            'neighborhood' => 'Old',
+            'city' => 'Old',
+            'state' => 'RJ',
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put("/family/{$family->id}", $this->validFamilyPayload([
+                'cpf' => $family->getRawOriginal('responsible_cpf'),
+                'data_nascimento' => now()->subYears(17)->format('Y-m-d'),
+            ]))
+            ->assertSessionHasErrors(['data_nascimento']);
+    }
+}

--- a/app/tests/Feature/FamilyWriteTest.php
+++ b/app/tests/Feature/FamilyWriteTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Constants\Messages;
 use App\Models\Family;
 use App\Models\FamilyMember;
 use App\Models\User;
@@ -53,6 +54,7 @@ class FamilyWriteTest extends TestCase
             ->post('/family', $this->validFamilyPayload());
 
         $response->assertRedirect('/family');
+        $response->assertSessionHas('success', Messages::MSG_16);
 
         $this->assertDatabaseHas('families', [
             'responsible_name' => 'João Silva',
@@ -98,7 +100,8 @@ class FamilyWriteTest extends TestCase
         $this->withSession(['_token' => 'test-token'])
             ->actingAs($user)
             ->post('/family', $payload)
-            ->assertRedirect('/family');
+            ->assertRedirect('/family')
+            ->assertSessionHas('success', Messages::MSG_16);
 
         $this->assertDatabaseHas('families', [
             'responsible_name' => 'João Silva',
@@ -140,6 +143,7 @@ class FamilyWriteTest extends TestCase
             ->put("/family/{$family->id}", $payload);
 
         $response->assertRedirect("/family/details/{$family->id}");
+        $response->assertSessionHas('success', Messages::MSG_14);
 
         $this->assertDatabaseHas('families', [
             'id' => $family->id,
@@ -169,7 +173,8 @@ class FamilyWriteTest extends TestCase
         $this->withSession(['_token' => 'test-token'])
             ->actingAs($user)
             ->put("/family/{$family->id}", $payload)
-            ->assertRedirect("/family/details/{$family->id}");
+            ->assertRedirect("/family/details/{$family->id}")
+            ->assertSessionHas('success', Messages::MSG_14);
 
         $this->assertDatabaseHas('addresses', [
             'id' => $oldAddress->id,
@@ -206,7 +211,8 @@ class FamilyWriteTest extends TestCase
         $this->withSession(['_token' => 'test-token'])
             ->actingAs($user)
             ->put("/family/{$family->id}", $payload)
-            ->assertRedirect("/family/details/{$family->id}");
+            ->assertRedirect("/family/details/{$family->id}")
+            ->assertSessionHas('success', Messages::MSG_14);
 
         $this->assertDatabaseMissing('family_members', ['id' => $oldMember->id]);
         $this->assertDatabaseHas('family_members', [
@@ -238,7 +244,8 @@ class FamilyWriteTest extends TestCase
         $this->withSession(['_token' => 'test-token'])
             ->actingAs($user)
             ->put("/family/{$family->id}", $payload)
-            ->assertRedirect("/family/details/{$family->id}");
+            ->assertRedirect("/family/details/{$family->id}")
+            ->assertSessionHas('success', Messages::MSG_14);
 
         $this->assertDatabaseCount('families', 1);
     }

--- a/app/tests/Feature/FamilyWriteTest.php
+++ b/app/tests/Feature/FamilyWriteTest.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Family;
+use App\Models\FamilyMember;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FamilyWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function validFamilyPayload(array $overrides = []): array
+    {
+        return array_merge([
+            '_token' => 'test-token',
+            'name' => 'João Silva',
+            'cpf' => '12345678900',
+            'telefone' => '11999999999',
+            'email' => 'joao@example.com',
+            'data_nascimento' => '1990-01-01',
+            'cep' => '01001000',
+            'logradouro' => 'Rua Teste',
+            'numero' => '123',
+            'cidade' => 'São Paulo',
+            'UF' => 'SP',
+            'bairro' => 'Centro',
+            'moradia' => 'propria',
+            'fonte_renda' => 'Formal',
+            'renda_familiar' => '2500',
+            'recebe_auxilio' => 'sim',
+            'auxilios_recebidos' => 'Bolsa Família',
+            'general_observations' => 'Observação de teste',
+            'family_members' => [
+                [
+                    'name' => 'Maria Silva',
+                    'cpf' => '98765432100',
+                    'data_nascimento' => '2010-05-05',
+                    'relacao_parentesco' => 'Filho(a)',
+                ],
+            ],
+        ], $overrides);
+    }
+
+    public function test_store_creates_family_with_address_and_members(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $this->validFamilyPayload());
+
+        $response->assertRedirect('/family');
+
+        $this->assertDatabaseHas('families', [
+            'responsible_name' => 'João Silva',
+            'responsible_cpf' => '12345678900',
+            'responsible_phone' => '11999999999',
+            'responsible_email' => 'joao@example.com',
+            'total_income' => 250000,
+            'receives_government_aid' => true,
+            'government_aid_description' => 'Bolsa Família',
+            'housing_condition' => 'propria',
+            'general_observations' => 'Observação de teste',
+        ]);
+
+        $family = Family::where('responsible_cpf', '12345678900')->first();
+
+        $this->assertDatabaseHas('addresses', [
+            'family_id' => $family->id,
+            'zipcode' => '01001000',
+            'street' => 'Rua Teste',
+            'number' => '123',
+            'neighborhood' => 'Centro',
+            'city' => 'São Paulo',
+            'state' => 'SP',
+        ]);
+
+        $this->assertDatabaseHas('family_members', [
+            'family_id' => $family->id,
+            'name' => 'Maria Silva',
+            'cpf' => '98765432100',
+            'relationship' => 'Filho(a)',
+        ]);
+    }
+
+    public function test_store_persists_cpf_digits_only_when_formatted_input_is_sent(): void
+    {
+        $user = User::factory()->create();
+        $payload = $this->validFamilyPayload([
+            'cpf' => '123.456.789-00',
+            'telefone' => '(11) 99999-9999',
+            'cep' => '01001-000',
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->post('/family', $payload)
+            ->assertRedirect('/family');
+
+        $this->assertDatabaseHas('families', [
+            'responsible_name' => 'João Silva',
+            'responsible_cpf' => '12345678900',
+            'responsible_phone' => '11999999999',
+        ]);
+
+        $this->assertDatabaseHas('addresses', [
+            'zipcode' => '01001000',
+        ]);
+    }
+
+    public function test_update_modifies_family_data(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create();
+        $family->address()->create([
+            'zipcode' => '00000000',
+            'street' => 'Old Street',
+            'number' => '1',
+            'neighborhood' => 'Old',
+            'city' => 'Old City',
+            'state' => 'RJ',
+        ]);
+        FamilyMember::factory()->for($family)->create([
+            'name' => 'Old Member',
+            'cpf' => '11111111111',
+        ]);
+
+        $payload = $this->validFamilyPayload([
+            'name' => 'João Atualizado',
+            'cpf' => $family->getRawOriginal('responsible_cpf'),
+            'email' => 'atualizado@example.com',
+            'renda_familiar' => '3000',
+        ]);
+
+        $response = $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put("/family/{$family->id}", $payload);
+
+        $response->assertRedirect("/family/details/{$family->id}");
+
+        $this->assertDatabaseHas('families', [
+            'id' => $family->id,
+            'responsible_name' => 'João Atualizado',
+            'responsible_email' => 'atualizado@example.com',
+            'total_income' => 300000,
+        ]);
+    }
+
+    public function test_update_upserts_address(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create();
+        $oldAddress = $family->address()->create([
+            'zipcode' => '00000000',
+            'street' => 'Old Street',
+            'number' => '1',
+            'neighborhood' => 'Old',
+            'city' => 'Old City',
+            'state' => 'RJ',
+        ]);
+
+        $payload = $this->validFamilyPayload([
+            'cpf' => $family->getRawOriginal('responsible_cpf'),
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put("/family/{$family->id}", $payload)
+            ->assertRedirect("/family/details/{$family->id}");
+
+        $this->assertDatabaseHas('addresses', [
+            'id' => $oldAddress->id,
+            'family_id' => $family->id,
+            'zipcode' => '01001000',
+            'street' => 'Rua Teste',
+            'state' => 'SP',
+        ]);
+
+        $this->assertDatabaseCount('addresses', 1);
+    }
+
+    public function test_update_replaces_members(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create();
+        $oldMember = FamilyMember::factory()->for($family)->create([
+            'name' => 'Old Member',
+            'cpf' => '11111111111',
+        ]);
+
+        $payload = $this->validFamilyPayload([
+            'cpf' => $family->getRawOriginal('responsible_cpf'),
+            'family_members' => [
+                [
+                    'name' => 'Novo Membro',
+                    'cpf' => '22222222222',
+                    'data_nascimento' => '2015-03-10',
+                    'relacao_parentesco' => 'Cônjuge',
+                ],
+            ],
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put("/family/{$family->id}", $payload)
+            ->assertRedirect("/family/details/{$family->id}");
+
+        $this->assertDatabaseMissing('family_members', ['id' => $oldMember->id]);
+        $this->assertDatabaseHas('family_members', [
+            'family_id' => $family->id,
+            'name' => 'Novo Membro',
+            'cpf' => '22222222222',
+            'relationship' => 'Cônjuge',
+        ]);
+        $this->assertDatabaseCount('family_members', 1);
+    }
+
+    public function test_update_ignores_unique_cpf_for_same_family(): void
+    {
+        $user = User::factory()->create();
+        $family = Family::factory()->create();
+        $family->address()->create([
+            'zipcode' => '00000000',
+            'street' => 'Old',
+            'number' => '1',
+            'neighborhood' => 'Old',
+            'city' => 'Old',
+            'state' => 'RJ',
+        ]);
+
+        $payload = $this->validFamilyPayload([
+            'cpf' => $family->getRawOriginal('responsible_cpf'),
+        ]);
+
+        $this->withSession(['_token' => 'test-token'])
+            ->actingAs($user)
+            ->put("/family/{$family->id}", $payload)
+            ->assertRedirect("/family/details/{$family->id}");
+
+        $this->assertDatabaseCount('families', 1);
+    }
+}

--- a/app/tests/Pest.php
+++ b/app/tests/Pest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -11,8 +14,8 @@
 |
 */
 
-pest()->extend(Tests\TestCase::class)
-    ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
+pest()->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
     ->in('Feature');
 
 /*

--- a/app/tests/Unit/Casts/MaskedCpfTest.php
+++ b/app/tests/Unit/Casts/MaskedCpfTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\Casts;
+
+use App\Casts\MaskedCpf;
+use App\Models\Family;
+use PHPUnit\Framework\TestCase;
+
+class MaskedCpfTest extends TestCase
+{
+    public function test_set_strips_non_digits_from_cpf(): void
+    {
+        $cast = new MaskedCpf;
+        $model = new Family;
+
+        $result = $cast->set($model, 'responsible_cpf', '123.456.789-00', []);
+
+        $this->assertSame('12345678900', $result);
+    }
+
+    public function test_set_returns_null_for_null_value(): void
+    {
+        $cast = new MaskedCpf;
+        $model = new Family;
+
+        $result = $cast->set($model, 'responsible_cpf', null, []);
+
+        $this->assertNull($result);
+    }
+
+    public function test_set_returns_null_for_empty_string(): void
+    {
+        $cast = new MaskedCpf;
+        $model = new Family;
+
+        $result = $cast->set($model, 'responsible_cpf', '', []);
+
+        $this->assertNull($result);
+    }
+
+    public function test_get_masks_first_three_and_last_two_digits(): void
+    {
+        $cast = new MaskedCpf;
+        $model = new Family;
+
+        $result = $cast->get($model, 'responsible_cpf', '12345678900', []);
+
+        $this->assertSame('***.456.789-**', $result);
+    }
+
+    public function test_get_returns_null_for_null_value(): void
+    {
+        $cast = new MaskedCpf;
+        $model = new Family;
+
+        $result = $cast->get($model, 'responsible_cpf', null, []);
+
+        $this->assertNull($result);
+    }
+
+    public function test_get_returns_null_for_empty_string(): void
+    {
+        $cast = new MaskedCpf;
+        $model = new Family;
+
+        $result = $cast->get($model, 'responsible_cpf', '', []);
+
+        $this->assertNull($result);
+    }
+
+    public function test_roundtrip_masks_stored_digits(): void
+    {
+        $cast = new MaskedCpf;
+        $model = new Family;
+
+        $stored = $cast->set($model, 'responsible_cpf', '123.456.789-00', []);
+        $masked = $cast->get($model, 'responsible_cpf', $stored, []);
+
+        $this->assertSame('12345678900', $stored);
+        $this->assertSame('***.456.789-**', $masked);
+    }
+}


### PR DESCRIPTION
Cria testes unitarios e de feature para o modulo de familia, incluindo cast MaskedCpf, auth gates, CRUD, validacoes e estado (activate/deactivate). Tambem adiciona flash messages de sucesso no FamilyController e a constante MSG_20.\n\nCloses #88